### PR TITLE
Fix GCB compliance-check logic against TWGCB-01-012 v1.2

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -100,21 +100,21 @@ check_filesystem() {
     print_header "磁碟與檔案系統 (1/3)"
 
     # TWGCB-01-012-0001: 停用 cramfs 檔案系統
-    if ! modprobe -n -v cramfs | grep -q "install /bin/true" && ! lsmod | grep -q "cramfs"; then
+    if modprobe -n -v cramfs 2>/dev/null | grep -q "install /bin/true" && ! lsmod | grep -q "cramfs"; then
         print_pass "TWGCB-01-012-0001: cramfs 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0001: cramfs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     # TWGCB-01-012-0002: 停用 squashfs 檔案系統
-    if ! modprobe -n -v squashfs | grep -q "install /bin/true" && ! lsmod | grep -q "squashfs"; then
+    if modprobe -n -v squashfs 2>/dev/null | grep -q "install /bin/true" && ! lsmod | grep -q "squashfs"; then
         print_pass "TWGCB-01-012-0002: squashfs 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0002: squashfs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     # TWGCB-01-012-0003: 停用 udf 檔案系統
-    if ! modprobe -n -v udf | grep -q "install /bin/true" && ! lsmod | grep -q "udf"; then
+    if modprobe -n -v udf 2>/dev/null | grep -q "install /bin/true" && ! lsmod | grep -q "udf"; then
         print_pass "TWGCB-01-012-0003: udf 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0003: udf 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
@@ -171,21 +171,28 @@ check_filesystem() {
     fi
 
     # TWGCB-01-012-0031: 停用 USB 儲存裝置
-    if ! modprobe -n -v usb-storage | grep -q "install /bin/true" && ! lsmod | grep -q "usb_storage"; then
+    if modprobe -n -v usb-storage 2>/dev/null | grep -q "install /bin/true" && ! lsmod | grep -q "usb_storage"; then
         print_pass "TWGCB-01-012-0031: USB 儲存裝置已停用。"
     else
         print_fail "TWGCB-01-012-0031: USB 儲存裝置未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     print_header "磁碟與檔案系統 (3/3)"
-    # 新增項目檢查 from v1.1
-    # TWGCB-01-012-0285 to 0297, 0299-0300: 停用各種檔案系統
-    FS_TO_DISABLE=(freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfsd)
-    for fs in "${FS_TO_DISABLE[@]}"; do
-        if ! modprobe -n -v "$fs" | grep -q "install /bin/true" && ! lsmod | grep -q "$fs"; then
-            print_pass "TWGCB-01-012-XXXX: $fs 檔案系統已停用。"
+    # TWGCB-01-012-0285 ~ 0300: 停用各種非必要之檔案系統
+    # ID 對照與 GCB_SET/GCB.sh 套用之項目一致
+    declare -A FS_TO_DISABLE=(
+        ["0285"]="freevxfs" ["0286"]="hfs"      ["0287"]="hfsplus" ["0288"]="jffs2"
+        ["0289"]="afs"      ["0290"]="ceph"     ["0291"]="cifs"    ["0292"]="exfat"
+        ["0293"]="ext"      ["0294"]="fat"      ["0295"]="fscache" ["0296"]="fuse"
+        ["0297"]="gfs2"     ["0298"]="nfs_common" ["0299"]="nfsd"  ["0300"]="smbfs_common"
+    )
+    for id in $(printf '%s\n' "${!FS_TO_DISABLE[@]}" | sort); do
+        fs="${FS_TO_DISABLE[$id]}"
+        mod="${fs//-/_}"
+        if modprobe -n -v "$fs" 2>/dev/null | grep -q "install /bin/true" && ! lsmod | grep -q "^${mod} "; then
+            print_pass "TWGCB-01-012-${id}: ${fs} 檔案系統已停用。"
         else
-            print_fail "TWGCB-01-012-XXXX: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
+            print_fail "TWGCB-01-012-${id}: ${fs} 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
         fi
     done
 }

--- a/GCB_SET/GCB_sshd.sh
+++ b/GCB_SET/GCB_sshd.sh
@@ -2,7 +2,7 @@
 
 #================================================================================
 # Red Hat Enterprise Linux 9 - SSH & PAM Government Configuration Baseline (GCB)
-# 文件版本: TWGCB-01-012 (v1.3)
+# 文件版本: TWGCB-01-012 (v1.2)
 #
 # 新增功能 v3: 腳本啟動時自動備份 sshd_config 與 /etc/pam.d 目錄。
 # 新增功能 v2: 若 sshd 服務重啟失敗，將自動匯出狀態日誌以供除錯。


### PR DESCRIPTION
## 背景

依需求檢視 NICS（國家資通安全研究院）公告之政府組態基準。經查，本專案目前引用的版本即為**最新版本**，無需升版：

- RHEL 9 — `TWGCB-01-012` **v1.2**（中華民國114年6月 / 2025-06）
- Apache HTTP Server 2.4 — `TWGCB-04-007` **v1.2**

> 註：本次執行環境的網路政策封鎖了 `nics.nat.gov.tw` / `download.nics.nat.gov.tw`，無法直接下載 PDF；版本資訊以公開搜尋結果交叉確認。

由於沒有新版文件可遷移，本 PR 聚焦修正稽核腳本中可驗證的**邏輯錯誤與一致性問題**。

## 變更內容

### `GCB_CHECK/GCB_check.sh`
- **修正反向的模組停用判斷**：原本 `modprobe` 管線前多了一個 `!`，導致判斷顛倒——已正確強化（`install <mod> /bin/true`，即 `GCB_SET/GCB.sh` 所寫入的設定）的系統會被判為 **FAIL**，而未強化的系統反而 **PASS**。影響 `cramfs`/`squashfs`/`udf`/`usb-storage`(0001/0002/0003/0031) 及檔案系統迴圈。
- **修正佔位 ID**：檔案系統迴圈原本對每個項目都印出 `TWGCB-01-012-XXXX`，現改為實際的 `0285`–`0300` 對照，並與 `GCB_SET/GCB.sh` 實際套用之清單同步（補上 `nfs_common`、`smbfs_common`）。
- 將 `lsmod` 比對加上字首/字尾錨點，避免子字串誤判（如 `ext` 誤中 `ext4`、`fat` 誤中 `vfat`）。

### `GCB_SET/GCB_sshd.sh`
- 修正檔頭版本標示：`TWGCB-01-012 (v1.3)` → `(v1.2)`。RHEL 9 的基準為 v1.2；v1.3 是 RHEL 8 的文件（`TWGCB-01-008`）。

## 驗證
- `bash -n` 語法檢查兩個檔案皆通過。
- 模擬驗證：停用之模組 → PASS、未停用之模組 → FAIL（修正前為相反）。
- 迴圈輸出 ID 順序正確（0285 → 0300）。

https://claude.ai/code/session_019PfD9qK3bk5c7uvtsPUN3r

---
_Generated by [Claude Code](https://claude.ai/code/session_019PfD9qK3bk5c7uvtsPUN3r)_