### PR TITLE
Fix GCB version label in GCB_sshd.sh (TWGCB-01-012 v1.2)

### DIFF
--- a/GCB_SET/GCB_sshd.sh
+++ b/GCB_SET/GCB_sshd.sh
@@ -2,7 +2,7 @@
 
 #================================================================================
 # Red Hat Enterprise Linux 9 - SSH & PAM Government Configuration Baseline (GCB)
-# 文件版本: TWGCB-01-012 (v1.3)
+# 文件版本: TWGCB-01-012 (v1.2)
 #
 # 新增功能 v3: 腳本啟動時自動備份 sshd_config 與 /etc/pam.d 目錄。
 # 新增功能 v2: 若 sshd 服務重啟失敗，將自動匯出狀態日誌以供除錯。


### PR DESCRIPTION
## Summary

針對 NICS 官方網站 (https://www.nics.nat.gov.tw/) 進行 GCB 版本核對後的修正。

- **版本核對結果**：
  - `TWGCB-01-012` Red Hat Enterprise Linux 9（伺服器）目前最新版本為 **v1.2**（2025-06-12 發布），repo 已對齊。
  - `TWGCB-04-007` Apache HTTP Server 2.4 目前最新版本為 **v1.2**（2022-12-26 發布），repo 已對齊。
  - v1.2 唯一變更項目（`-0272` SSH 連線逾時：`ClientAliveInterval ≤ 600`、`ClientAliveCountMax = 1`）已於 set/check 腳本中實作。

- **本次修正**：`GCB_SET/GCB_sshd.sh` 標頭誤標為 `TWGCB-01-012 (v1.3)`。v1.3 為 RHEL 8 基準（TWGCB-01-008）之版本；RHEL 9 基準（TWGCB-01-012）為 v1.2。已與 repo 其餘檔案（README、`GCB.sh`、`GCB_check.sh`）一致改為 v1.2。

## 備註

由於本執行環境的網路允許清單封鎖了 `download.nics.nat.gov.tw`，且 `www.nics.nat.gov.tw` 對自動抓取回傳 403，無法在此環境直接下載官方文件做逐條規則比對。上述版本資訊以公開搜尋結果交叉確認。若需逐條規則 diff，請放寬網路存取或提供文件內容。

## Test plan

- [ ] `bash -n GCB_SET/GCB_sshd.sh` 語法檢查通過（僅變更註解，無行為改變）
- [ ] 人工確認標頭版本與 README/其他腳本一致為 v1.2

https://claude.ai/code/session_012b1Eebr2MsryBru5PKQoH1

---
_Generated by [Claude Code](https://claude.ai/code/session_012b1Eebr2MsryBru5PKQoH1)_