### PR TITLE
對照 NICS 最新 GCB 版本，修正檢測項目編號與文件版本標示

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -178,14 +178,21 @@ check_filesystem() {
     fi
 
     print_header "磁碟與檔案系統 (3/3)"
-    # 新增項目檢查 from v1.1
-    # TWGCB-01-012-0285 to 0297, 0299-0300: 停用各種檔案系統
-    FS_TO_DISABLE=(freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfsd)
-    for fs in "${FS_TO_DISABLE[@]}"; do
+    # 新增項目檢查 from v1.1 (TWGCB-01-012-0285 至 0300: 停用各種檔案系統)
+    # 項目編號與停用模組對應 GCB_SET/GCB.sh 之套用設定。
+    FS_TO_DISABLE=(
+        "0285:freevxfs" "0286:hfs" "0287:hfsplus" "0288:jffs2"
+        "0289:afs" "0290:ceph" "0291:cifs" "0292:exfat"
+        "0293:ext" "0294:fat" "0295:fscache" "0296:fuse"
+        "0297:gfs2" "0298:nfs_common" "0299:nfsd" "0300:smbfs_common"
+    )
+    for entry in "${FS_TO_DISABLE[@]}"; do
+        local id="${entry%%:*}"
+        local fs="${entry#*:}"
         if ! modprobe -n -v "$fs" | grep -q "install /bin/true" && ! lsmod | grep -q "$fs"; then
-            print_pass "TWGCB-01-012-XXXX: $fs 檔案系統已停用。"
+            print_pass "TWGCB-01-012-${id}: $fs 檔案系統已停用。"
         else
-            print_fail "TWGCB-01-012-XXXX: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
+            print_fail "TWGCB-01-012-${id}: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
         fi
     done
 }

--- a/GCB_SET/GCB_sshd.sh
+++ b/GCB_SET/GCB_sshd.sh
@@ -2,7 +2,7 @@
 
 #================================================================================
 # Red Hat Enterprise Linux 9 - SSH & PAM Government Configuration Baseline (GCB)
-# 文件版本: TWGCB-01-012 (v1.3)
+# 文件版本: TWGCB-01-012 (v1.2)
 #
 # 新增功能 v3: 腳本啟動時自動備份 sshd_config 與 /etc/pam.d 目錄。
 # 新增功能 v2: 若 sshd 服務重啟失敗，將自動匯出狀態日誌以供除錯。

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@
 
 **目的**：簡化並加速 Rocky Linux 9 系統的 GCB 安全性設定與檢測流程，透過自動化腳本減少人為疏失，確保設定一致性。
 
-**依據文件**：
-- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2
-- `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 v1.2
+**依據文件**（依國家資通安全研究院 NICS 公告之最新版本）：
+- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) **v1.2**（中華民國114年6月／2025-06-12 發布）
+- `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 **v1.2**（中華民國111年12月／2022-12-26 發布）
+
+> 來源：[國家資通安全研究院 - GCB 說明文件](https://www.nics.nat.gov.tw/core_business/cybersecurity_defense/GCB/GCB_Documentation/)
+
+**TWGCB-01-012 版本沿革**：
+- v1.0（2023-12-07）：初版
+- v1.1（2025-03-11）：新增 31 項、刪除 1 項、修改 2 項（含 0285–0300 停用各檔案系統模組等）
+- v1.2（2025-06-12）：修改 1 項（SSH 連線逾時 TWGCB-01-012-0272：`ClientAliveInterval` ≤ 600、`ClientAliveCountMax` = 1）
 
 **核心特色**：
 - 🔍 **完整檢測**：全面掃描系統現狀與 GCB 規範的符合程度
@@ -337,7 +344,7 @@ sudo /usr/local/apache/bin/apachectl restart
 ---
 
 **維護者**：warden  
-**最後更新**：2025-01-15  
-**版本**：2.0
+**最後更新**：2026-05-27（已對照 NICS 公告之 TWGCB-01-012 v1.2 / TWGCB-04-007 v1.2）  
+**版本**：2.1
 
 如有問題或建議，請透過 GitHub Issues 回報。


### PR DESCRIPTION
## 摘要

依任務要求查核 [國家資通安全研究院（NICS）](https://www.nics.nat.gov.tw/) 公告之政府組態基準（GCB），並更新本專案規則／版本標示。

### 查核結果（NICS 最新版本）
- **TWGCB-01-012** Red Hat Enterprise Linux 9（伺服器）：最新為 **v1.2**（2025-06-12 發布）
- **TWGCB-04-007** Apache HTTP Server 2.4：最新為 **v1.2**（2022-12-26 發布）
- 兩者皆與本專案既有依據版本一致，故毋須改版基準。TWGCB-01-012 版本沿革：v1.0 → v1.1（+31 項）→ v1.2（修改 1 項，即 SSH 逾時 0272）。

### 本 PR 變更
- **`GCB_CHECK/GCB_check.sh`**：v1.1 停用檔案系統檢查原本輸出 `TWGCB-01-012-XXXX` 佔位字串。改用正確項目編號 **0285–0300**，並補上 `nfs_common`（0298）與 `smbfs_common`（0300），使檢測項目與 `GCB_SET/GCB.sh` 之套用設定完全對應。
- **`GCB_SET/GCB_sshd.sh`**：標頭文件版本由誤植的 `TWGCB-01-012 (v1.3)` 修正為 **`(v1.2)`**（NICS 並無 v1.3；v1.3 為 RHEL 8 之 TWGCB-01-008）。
- **`README.md`**：補上依據文件之發布日期與 NICS 來源連結、TWGCB-01-012 版本沿革，並更新維護資訊。

## 已知問題（不在本 PR 範圍）
- `GCB_SET/GCB_apache.sh` 與 `GCB_SET/iptables_to_firewalld.sh` 在 `main` 上即為 **CRLF（Windows）行尾**，於 Linux 直接執行會出現 `$'{\r'` 語法錯誤。屬既有問題，未在此處一併處理以維持變更聚焦。

## 測試
- [x] `bash -n` 通過：`GCB_check.sh`、`GCB_sshd.sh`、`GCB.sh`、`GCB_check_apache.sh`
- [ ] 於 Rocky Linux 9 / RHEL 9 實機執行檢測與設定腳本（需具備測試環境）

https://claude.ai/code/session_0117MkWpzmXnCuwSm8f8ndLd

---
_Generated by [Claude Code](https://claude.ai/code/session_0117MkWpzmXnCuwSm8f8ndLd)_