### PR TITLE
更新 GCB 規則：同步 NICS TWGCB-01-012 v1.2

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
 # ==============================================================================
-# Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v2
+# Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v3
 #
 # 作者: warden
-# 日期: 2025-07-15
+# 日期: 2026-05-30
+# 依據: NICS 國家資通安全研究院 TWGCB-01-012 v1.2 (114年6月12日發布)
 #
 # 功能更新:
 # 1. 新增日誌匯出功能至 /var/log/
 # 2. 針對 TWGCB-01-012-0063 項目新增檔案數量統計
 # 3. 新增 CLI 統計摘要 (通過/未通過數量與比率)
+# 4. 修正檔案系統停用檢查之邏輯錯誤 (反向判斷)
+# 5. 為 v1.1 新增之檔案系統項目 (0285-0300) 補上對應 TWGCB-ID
+# 6. 新增 v1.1 缺漏之檢查項目: 0298, 0300, 0303-0309, 0312
 #
 # 免責聲明: 此腳本僅用於檢測，不會修改任何系統設定。
 # 執行前請詳閱腳本內容。建議以 root 權限執行以獲得最準確的結果。
@@ -86,6 +90,13 @@ print_skip() {
     ((SKIP_COUNT++))
 }
 
+# 共用檢查函式：模組是否被禁用且未載入
+is_module_disabled() {
+    local mod="$1"
+    modprobe -n -v "$mod" 2>/dev/null | grep -qE "install /bin/(true|false)" \
+        && ! lsmod | awk '{print $1}' | grep -qw "${mod//-/_}"
+}
+
 # --- Root Check ---
 if [[ $EUID -ne 0 ]]; then
    print_fail "此腳本需要 root 權限才能完整執行。請使用 'sudo ./check_rhel9_gcb.sh' 執行。"
@@ -100,21 +111,21 @@ check_filesystem() {
     print_header "磁碟與檔案系統 (1/3)"
 
     # TWGCB-01-012-0001: 停用 cramfs 檔案系統
-    if ! modprobe -n -v cramfs | grep -q "install /bin/true" && ! lsmod | grep -q "cramfs"; then
+    if is_module_disabled cramfs; then
         print_pass "TWGCB-01-012-0001: cramfs 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0001: cramfs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     # TWGCB-01-012-0002: 停用 squashfs 檔案系統
-    if ! modprobe -n -v squashfs | grep -q "install /bin/true" && ! lsmod | grep -q "squashfs"; then
+    if is_module_disabled squashfs; then
         print_pass "TWGCB-01-012-0002: squashfs 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0002: squashfs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     # TWGCB-01-012-0003: 停用 udf 檔案系統
-    if ! modprobe -n -v udf | grep -q "install /bin/true" && ! lsmod | grep -q "udf"; then
+    if is_module_disabled udf; then
         print_pass "TWGCB-01-012-0003: udf 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0003: udf 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
@@ -171,21 +182,39 @@ check_filesystem() {
     fi
 
     # TWGCB-01-012-0031: 停用 USB 儲存裝置
-    if ! modprobe -n -v usb-storage | grep -q "install /bin/true" && ! lsmod | grep -q "usb_storage"; then
+    if is_module_disabled usb-storage; then
         print_pass "TWGCB-01-012-0031: USB 儲存裝置已停用。"
     else
         print_fail "TWGCB-01-012-0031: USB 儲存裝置未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
-    print_header "磁碟與檔案系統 (3/3)"
-    # 新增項目檢查 from v1.1
-    # TWGCB-01-012-0285 to 0297, 0299-0300: 停用各種檔案系統
-    FS_TO_DISABLE=(freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfsd)
-    for fs in "${FS_TO_DISABLE[@]}"; do
-        if ! modprobe -n -v "$fs" | grep -q "install /bin/true" && ! lsmod | grep -q "$fs"; then
-            print_pass "TWGCB-01-012-XXXX: $fs 檔案系統已停用。"
+    print_header "磁碟與檔案系統 (3/3) - v1.1 新增項目"
+    # TWGCB-01-012-0285 至 0300: 停用各種檔案系統 (v1.1 新增)
+    # 對應表: ID => 模組名稱
+    declare -A FS_ID_MAP=(
+        [0285]=freevxfs
+        [0286]=hfs
+        [0287]=hfsplus
+        [0288]=jffs2
+        [0289]=afs
+        [0290]=ceph
+        [0291]=cifs
+        [0292]=exfat
+        [0293]=ext
+        [0294]=fat
+        [0295]=fscache
+        [0296]=fuse
+        [0297]=gfs2
+        [0298]=nfs_common
+        [0299]=nfsd
+        [0300]=smbfs_common
+    )
+    for id in $(echo "${!FS_ID_MAP[@]}" | tr ' ' '\n' | sort); do
+        fs="${FS_ID_MAP[$id]}"
+        if is_module_disabled "$fs"; then
+            print_pass "TWGCB-01-012-${id}: ${fs} 檔案系統已停用。"
         else
-            print_fail "TWGCB-01-012-XXXX: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
+            print_fail "TWGCB-01-012-${id}: ${fs} 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
         fi
     done
 }
@@ -322,6 +351,63 @@ check_system_settings() {
         local details="CLI僅顯示前10筆，完整列表請見日誌檔。\n$(echo "$NO_GROUP_FILES" | head -n 10)"
         print_fail "TWGCB-01-012-0063: 發現 ${file_count} 個無擁有群組之檔案。" "$details"
         echo -e "\n--- 無擁有群組之檔案完整列表 ---\n$NO_GROUP_FILES" >> "$LOG_FILE"
+    fi
+
+    # --- v1.1 新增之系統維護相關檢查項目 ---
+
+    # TWGCB-01-012-0303 & 0304: /etc/security/opasswd 檔案所有權與權限
+    if [ -f /etc/security/opasswd ]; then
+        check_file_perms_owner "TWGCB-01-012-0303/04" "/etc/security/opasswd" "644" "root:root"
+    else
+        print_info "TWGCB-01-012-0303/04: /etc/security/opasswd 不存在，略過檢查。"
+    fi
+    if [ -f /etc/security/opasswd.old ]; then
+        check_file_perms_owner "TWGCB-01-012-0303/04" "/etc/security/opasswd.old" "644" "root:root"
+    fi
+
+    # TWGCB-01-012-0305: /etc/shells 中不應存在 nologin
+    if grep -qE '^[^#]*/(s)?bin/nologin$' /etc/shells 2>/dev/null; then
+        print_fail "TWGCB-01-012-0305: /etc/shells 中包含 nologin，應移除。"
+    else
+        print_pass "TWGCB-01-012-0305: /etc/shells 中未包含 nologin。"
+    fi
+
+    # TWGCB-01-012-0306: 禁止 chrony 以 root 權限執行
+    if grep -qE '^\s*OPTIONS=.*-u\s+chrony' /etc/sysconfig/chronyd 2>/dev/null \
+       || grep -qE '^\s*OPTIONS=.*-F\s+[0-9]+' /etc/sysconfig/chronyd 2>/dev/null; then
+        print_pass "TWGCB-01-012-0306: chrony 已設定為非 root 執行身份。"
+    else
+        print_fail "TWGCB-01-012-0306: /etc/sysconfig/chronyd 未設定非 root 執行身份 (OPTIONS=\"-F 2\")。"
+    fi
+
+    # TWGCB-01-012-0307: 啟用 ptrace 限制模式
+    PTRACE_VAL=$(sysctl -n kernel.yama.ptrace_scope 2>/dev/null)
+    if [[ "$PTRACE_VAL" =~ ^[1-3]$ ]]; then
+        print_pass "TWGCB-01-012-0307: kernel.yama.ptrace_scope 為 ${PTRACE_VAL}，符合 >= 1 之限制要求。"
+    else
+        print_fail "TWGCB-01-012-0307: kernel.yama.ptrace_scope 為 ${PTRACE_VAL:-未設定}，應 >= 1。"
+    fi
+
+    # TWGCB-01-012-0308: 啟用 rsyslog logrotate
+    if [ -f /etc/logrotate.d/rsyslog ] || grep -qsE 'rsyslog|/var/log/messages' /etc/logrotate.conf /etc/logrotate.d/* 2>/dev/null; then
+        print_pass "TWGCB-01-012-0308: rsyslog logrotate 已設定。"
+    else
+        print_fail "TWGCB-01-012-0308: rsyslog logrotate 設定檔未發現，應啟用日誌輪替。"
+    fi
+
+    # TWGCB-01-012-0309: root 之預設 umask
+    ROOT_UMASK=$(grep -hE '^\s*umask' /root/.bashrc /root/.bash_profile 2>/dev/null | tail -n1 | awk '{print $2}')
+    if [[ "$ROOT_UMASK" == "027" || "$ROOT_UMASK" == "077" ]]; then
+        print_pass "TWGCB-01-012-0309: root 預設 umask 為 ${ROOT_UMASK}，符合要求。"
+    else
+        print_fail "TWGCB-01-012-0309: root 預設 umask 為 ${ROOT_UMASK:-未設定}，應為 027 或更嚴格。"
+    fi
+
+    # TWGCB-01-012-0312: 停用 PAM 模組 nullok (即 without-nullok)
+    if grep -qsE '^\s*password\s+.*\bnullok\b' /etc/pam.d/system-auth /etc/pam.d/password-auth 2>/dev/null; then
+        print_fail "TWGCB-01-012-0312: PAM 設定檔仍包含 nullok，應移除以禁止空通行碼。"
+    else
+        print_pass "TWGCB-01-012-0312: PAM 設定已停用 nullok (without-nullok)。"
     fi
 }
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@
 **目的**：簡化並加速 Rocky Linux 9 系統的 GCB 安全性設定與檢測流程，透過自動化腳本減少人為疏失，確保設定一致性。
 
 **依據文件**：
-- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2
-- `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 v1.2
+- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2 (NICS 114年6月12日發布)
+- `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 v1.2 (NICS 111年12月26日發布)
+
+> 最新版本可至 [國家資通安全研究院 GCB 說明文件](https://www.nics.nat.gov.tw/core_business/cybersecurity_defense/GCB/GCB_Documentation/) 下載確認。
 
 **核心特色**：
 - 🔍 **完整檢測**：全面掃描系統現狀與 GCB 規範的符合程度
@@ -337,7 +339,22 @@ sudo /usr/local/apache/bin/apachectl restart
 ---
 
 **維護者**：warden  
-**最後更新**：2025-01-15  
-**版本**：2.0
+**最後更新**：2026-05-30  
+**版本**：2.1
+
+### 更新摘要 (v2.1)
+
+- 同步 NICS 114 年 6 月 12 日發布之 **TWGCB-01-012 v1.2** 規則
+- `GCB_CHECK/GCB_check.sh`
+  - 修正 `cramfs`、`squashfs`、`udf`、`usb-storage` 之檔案系統停用判斷邏輯 (原為反向判斷)
+  - 將 v1.1 新增之 16 項檔案系統停用檢查 (0285–0300) 補上對應 TWGCB-ID，並加入 `nfs_common` (0298) 與 `smbfs_common` (0300)
+  - 新增 v1.1 缺漏之檢查項目：
+    - `TWGCB-01-012-0303/04` `/etc/security/opasswd` 檔案所有權與權限
+    - `TWGCB-01-012-0305` `/etc/shells` 不應包含 `nologin`
+    - `TWGCB-01-012-0306` 禁止 `chrony` 以 root 權限執行
+    - `TWGCB-01-012-0307` 啟用 `kernel.yama.ptrace_scope` 限制模式
+    - `TWGCB-01-012-0308` 啟用 rsyslog logrotate
+    - `TWGCB-01-012-0309` root 預設 `umask`
+    - `TWGCB-01-012-0312` PAM `without-nullok` (禁止空通行碼)
 
 如有問題或建議，請透過 GitHub Issues 回報。


### PR DESCRIPTION
## Summary

依據國家資通安全研究院 (NICS) 於 114 年 6 月 12 日發布之 **TWGCB-01-012 v1.2** (Red Hat Enterprise Linux 9 政府組態基準說明文件 (伺服器))，補齊 v1.1 新增規則於 `GCB_check.sh` 中遺漏之檢測項目，並修正既有檔案系統停用檢查的反向邏輯錯誤。

來源：<https://www.nics.nat.gov.tw/core_business/cybersecurity_defense/GCB/GCB_Documentation/>

## Changes

### `GCB_CHECK/GCB_check.sh`

- 抽出 `is_module_disabled` 共用函式至全域範圍，集中模組停用判斷邏輯
- **修正既有 bug**：`cramfs` / `squashfs` / `udf` / `usb-storage` 之停用判斷邏輯為反向 (原本「已停用」反而會被判為 FAIL，反之亦然)
- 將 v1.1 新增之 16 項檔案系統停用檢查補上對應 TWGCB-ID (原本使用 `TWGCB-01-012-XXXX` 占位符)：

  | TWGCB-ID | 模組 | TWGCB-ID | 模組 |
  |---|---|---|---|
  | 0285 | freevxfs | 0293 | ext |
  | 0286 | hfs | 0294 | fat |
  | 0287 | hfsplus | 0295 | fscache |
  | 0288 | jffs2 | 0296 | fuse |
  | 0289 | afs | 0297 | gfs2 |
  | 0290 | ceph | 0298 | nfs_common (新增) |
  | 0291 | cifs | 0299 | nfsd |
  | 0292 | exfat | 0300 | smbfs_common (新增) |

- 新增 v1.1 在 `GCB.sh` 已套用但 `GCB_check.sh` 缺漏之檢測項目：
  - `TWGCB-01-012-0303/04` `/etc/security/opasswd` 檔案所有權與權限
  - `TWGCB-01-012-0305` `/etc/shells` 不應包含 `nologin`
  - `TWGCB-01-012-0306` 禁止 `chrony` 以 root 權限執行
  - `TWGCB-01-012-0307` 啟用 `kernel.yama.ptrace_scope` 限制模式
  - `TWGCB-01-012-0308` 啟用 rsyslog logrotate
  - `TWGCB-01-012-0309` root 預設 `umask`
  - `TWGCB-01-012-0312` PAM `without-nullok` (禁止空通行碼)

### `README.md`

- 於依據文件中補上 NICS 發布單位、發布日期與下載連結
- 新增 v2.1 更新摘要

## Test plan

- [x] `bash -n GCB_CHECK/GCB_check.sh` 語法檢查通過
- [x] `bash -n GCB_SET/GCB.sh` 語法檢查通過
- [ ] 於 Rocky Linux 9 測試機執行 `sudo ./GCB_CHECK/GCB_check.sh`，確認：
  - 16 項 v1.1 新增之檔案系統檢查項目皆以正確 TWGCB-ID 顯示
  - `TWGCB-01-012-0303` ~ `0312` 新檢查項目可正常運作
  - 修正後的 cramfs/squashfs/udf/usb-storage 之判斷結果與實際系統狀態一致
- [ ] 對照 `GCB.sh` 套用結果，確認 `GCB_check.sh` 能完整覆蓋

https://claude.ai/code/session_01Ph8kmiV91tMpCS2UB4Jsw2


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph8kmiV91tMpCS2UB4Jsw2)_