### PR TITLE
對齊 NICS TWGCB-01-012 v1.2 — 補齊 v1.1 檔案系統 ID 與防火牆檢查

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -2,6 +2,7 @@
 
 # ==============================================================================
 # Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v2
+# 對應文件: 國家資通安全研究院 TWGCB-01-012 v1.2 (民國114年6月12日)
 #
 # 作者: warden
 # 日期: 2025-07-15
@@ -10,6 +11,8 @@
 # 1. 新增日誌匯出功能至 /var/log/
 # 2. 針對 TWGCB-01-012-0063 項目新增檔案數量統計
 # 3. 新增 CLI 統計摘要 (通過/未通過數量與比率)
+# 4. 將 v1.1 新增之檔案系統檢查項目 (0285-0300) 由佔位 XXXX 改為對應 TWGCB ID
+# 5. 新增防火牆 (firewalld / nftables) 檢查 (0242-0248)
 #
 # 免責聲明: 此腳本僅用於檢測，不會修改任何系統設定。
 # 執行前請詳閱腳本內容。建議以 root 權限執行以獲得最準確的結果。
@@ -178,14 +181,43 @@ check_filesystem() {
     fi
 
     print_header "磁碟與檔案系統 (3/3)"
-    # 新增項目檢查 from v1.1
-    # TWGCB-01-012-0285 to 0297, 0299-0300: 停用各種檔案系統
-    FS_TO_DISABLE=(freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfsd)
-    for fs in "${FS_TO_DISABLE[@]}"; do
-        if ! modprobe -n -v "$fs" | grep -q "install /bin/true" && ! lsmod | grep -q "$fs"; then
-            print_pass "TWGCB-01-012-XXXX: $fs 檔案系統已停用。"
+    # v1.1 新增項目：停用各類非必要檔案系統 (TWGCB-01-012-0285~0300)
+    # 對應 GCB_SET/GCB.sh 之設定順序，逐項以正確 TWGCB ID 報告
+    local fs_items=(
+        "0285:freevxfs"
+        "0286:hfs"
+        "0287:hfsplus"
+        "0288:jffs2"
+        "0289:afs"
+        "0290:ceph"
+        "0291:cifs"
+        "0292:exfat"
+        "0293:ext"
+        "0294:fat"
+        "0295:fscache"
+        "0296:fuse"
+        "0297:gfs2"
+        "0298:nfs_common"
+        "0299:nfsd"
+        "0300:smbfs_common"
+    )
+    local lsmod_out
+    lsmod_out=$(lsmod)
+    for entry in "${fs_items[@]}"; do
+        local id="${entry%%:*}"
+        local fs="${entry##*:}"
+        local mod_re="^${fs//_/[_-]}([[:space:]]|$)"
+        local disabled=1
+        if ! modprobe -n -v "$fs" 2>/dev/null | grep -qE "install +/bin/(true|false)"; then
+            disabled=0
+        fi
+        if echo "$lsmod_out" | awk '{print $1}' | grep -Eq "$mod_re"; then
+            disabled=0
+        fi
+        if [ "$disabled" -eq 1 ]; then
+            print_pass "TWGCB-01-012-${id}: $fs 檔案系統已停用。"
         else
-            print_fail "TWGCB-01-012-XXXX: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
+            print_fail "TWGCB-01-012-${id}: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用 (install $fs /bin/true 並 blacklist $fs)。"
         fi
     done
 }
@@ -385,6 +417,50 @@ check_network() {
     fi
 }
 
+# 防火牆 (firewalld / nftables) — 兩者擇一啟用
+check_firewall() {
+    print_header "防火牆 (firewalld / nftables)"
+
+    local firewalld_installed=0 firewalld_active=0
+    local nftables_installed=0 nftables_active=0
+
+    rpm -q firewalld &> /dev/null && firewalld_installed=1
+    rpm -q nftables &> /dev/null && nftables_installed=1
+    systemctl is-active firewalld &> /dev/null && firewalld_active=1
+    systemctl is-active nftables &> /dev/null && nftables_active=1
+
+    # TWGCB-01-012-0242: 安裝 firewalld 套件 (使用 firewalld 時必要)
+    if [ "$firewalld_installed" -eq 1 ]; then
+        print_pass "TWGCB-01-012-0242: firewalld 套件已安裝。"
+    else
+        print_info "TWGCB-01-012-0242: firewalld 套件未安裝 (若使用 nftables 可忽略)。"
+    fi
+
+    # TWGCB-01-012-0243 / 0248: firewalld 與 nftables 二擇一啟用
+    if [ "$firewalld_active" -eq 1 ] && [ "$nftables_active" -eq 0 ]; then
+        print_pass "TWGCB-01-012-0243: firewalld 服務為啟用狀態。"
+        print_pass "TWGCB-01-012-0245: nftables 服務已停用 (使用 firewalld 模式)。"
+    elif [ "$nftables_active" -eq 1 ] && [ "$firewalld_active" -eq 0 ]; then
+        print_pass "TWGCB-01-012-0247: nftables 服務為啟用狀態。"
+        print_pass "TWGCB-01-012-0248: firewalld 服務已停用 (使用 nftables 模式)。"
+    elif [ "$firewalld_active" -eq 1 ] && [ "$nftables_active" -eq 1 ]; then
+        print_fail "TWGCB-01-012-0243/0247: firewalld 與 nftables 同時啟用，應僅擇一使用。"
+    else
+        print_fail "TWGCB-01-012-0243/0247: firewalld 與 nftables 皆未啟用，系統未受防火牆保護。"
+    fi
+
+    # TWGCB-01-012-0246: 使用 firewalld 時，預設區域應為 public
+    if [ "$firewalld_active" -eq 1 ]; then
+        local default_zone
+        default_zone=$(firewall-cmd --get-default-zone 2>/dev/null)
+        if [ "$default_zone" = "public" ]; then
+            print_pass "TWGCB-01-012-0246: firewalld 預設區域為 public。"
+        else
+            print_fail "TWGCB-01-012-0246: firewalld 預設區域為 ${default_zone:-未取得}，應為 public。"
+        fi
+    fi
+}
+
 # SELinux
 check_selinux() {
     print_header "SELinux"
@@ -562,6 +638,7 @@ main() {
     check_services
     check_software
     check_network
+    check_firewall
     check_selinux
     check_accounts
     check_ssh

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@
 
 **目的**：簡化並加速 Rocky Linux 9 系統的 GCB 安全性設定與檢測流程，透過自動化腳本減少人為疏失，確保設定一致性。
 
-**依據文件**：
-- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2
+**依據文件**（國家資通安全研究院 NICS 最新發布版本）：
+- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2（民國114年6月12日）
 - `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 v1.2
+
+> 來源：[國家資通安全研究院 GCB 說明文件](https://www.nics.nat.gov.tw/core_business/cybersecurity_defense/GCB/GCB_Documentation/)
+> 變更摘要：v1.1 (2025/03/11) 新增 31 項、刪除 1 項、修訂 2 項；v1.2 (2025/06/12) 修訂 1 項（SSH 逾時時間 TWGCB-01-012-0272）。
 
 **核心特色**：
 - 🔍 **完整檢測**：全面掃描系統現狀與 GCB 規範的符合程度
@@ -337,7 +340,7 @@ sudo /usr/local/apache/bin/apachectl restart
 ---
 
 **維護者**：warden  
-**最後更新**：2025-01-15  
-**版本**：2.0
+**最後更新**：2026-06-02（依 NICS TWGCB-01-012 v1.2 / 民國114年6月12日校對）  
+**版本**：2.1
 
 如有問題或建議，請透過 GitHub Issues 回報。


### PR DESCRIPTION
## 摘要

依國家資通安全研究院（NICS）最新發布之 **RHEL 9 政府組態基準 TWGCB-01-012 v1.2（民國114年6月12日）** 對齊 `GCB_CHECK/GCB_check.sh`，補齊兩處與 `GCB_SET/GCB.sh` 之間的落差。

> 來源：<https://www.nics.nat.gov.tw/core_business/cybersecurity_defense/GCB/GCB_Documentation/>
> 變更摘要：v1.1 (2025/03/11) 新增 31 項、刪除 1 項、修訂 2 項；v1.2 (2025/06/12) 修訂 1 項。

## 變更內容

### `GCB_CHECK/GCB_check.sh`
- 將 v1.1 新增之檔案系統檢查由佔位 `TWGCB-01-012-XXXX` 改為對應正式 ID（`0285`–`0300`），並補齊 SET 腳本已涵蓋但 CHECK 漏掉的 `nfs_common` (0298) 與 `smbfs_common` (0300)。
- 模組偵測同時檢查 `modprobe -n -v` 之 install 規則與 `lsmod` 載入狀態，並支援 `nfs_common` 等含底線之模組名稱。
- 新增 `check_firewall()`：覆蓋 firewalld / nftables 二擇一啟用之檢查（`0242`, `0243`, `0245`, `0246`, `0247`, `0248`）。

### `README.md`
- 在「依據文件」段落補上版本日期、變更摘要與 NICS 官方來源連結。
- 維護版本由 2.0 升為 2.1。

## 對照表

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| v1.1 檔案系統 ID | `TWGCB-01-012-XXXX`（共 14 項，列出但無正確 ID） | `TWGCB-01-012-0285` ~ `0300`（16 項，與 SET 腳本一致） |
| 防火牆檢查 | 無 | 新增 `check_firewall()` 覆蓋 0242/0243/0245/0246/0247/0248 |

## 測試計畫

- [x] `bash -n GCB_CHECK/GCB_check.sh` 通過
- [x] `bash -n GCB_SET/GCB.sh` 通過
- [ ] 於 Rocky Linux 9 測試機實際執行 `GCB_check.sh`，確認新增之檔案系統項目與防火牆檢查皆能正確產生 PASS/FAIL（待人工驗證）

https://claude.ai/code/session_01KUDfQZMEfstjGkFKUZ4s6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUDfQZMEfstjGkFKUZ4s6h)_