### PR TITLE
更新 GCB 規則對照至 NICS TWGCB-01-012 v1.2 (114/06/12)

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -178,14 +178,20 @@ check_filesystem() {
     fi
 
     print_header "磁碟與檔案系統 (3/3)"
-    # 新增項目檢查 from v1.1
-    # TWGCB-01-012-0285 to 0297, 0299-0300: 停用各種檔案系統
-    FS_TO_DISABLE=(freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfsd)
-    for fs in "${FS_TO_DISABLE[@]}"; do
-        if ! modprobe -n -v "$fs" | grep -q "install /bin/true" && ! lsmod | grep -q "$fs"; then
-            print_pass "TWGCB-01-012-XXXX: $fs 檔案系統已停用。"
+    # 新增項目檢查 (v1.1/v1.2)
+    # TWGCB-01-012-0285 to 0300: 停用各種檔案系統 (對應 ID)
+    declare -A FS_IDS=(
+        [freevxfs]="0285" [hfs]="0286" [hfsplus]="0287" [jffs2]="0288"
+        [afs]="0289" [ceph]="0290" [cifs]="0291" [exfat]="0292"
+        [ext]="0293" [fat]="0294" [fscache]="0295" [fuse]="0296"
+        [gfs2]="0297" [nfs_common]="0298" [nfsd]="0299" [smbfs_common]="0300"
+    )
+    for fs in "${!FS_IDS[@]}"; do
+        local id="TWGCB-01-012-0${FS_IDS[$fs]}"
+        if ! modprobe -n -v "$fs" 2>/dev/null | grep -q "install /bin/true" && ! lsmod | grep -q "^${fs} "; then
+            print_pass "$id: $fs 檔案系統已停用。"
         else
-            print_fail "TWGCB-01-012-XXXX: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
+            print_fail "$id: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
         fi
     done
 }
@@ -520,6 +526,19 @@ check_ssh() {
     # TWGCB-01-012-0274: SSH UsePAM
     grep -qE "^\s*UsePAM\s+yes" "$SSHD_CONFIG" && print_pass "TWGCB-01-012-0274: SSH UsePAM 已設為 yes。" || print_fail "TWGCB-01-012-0274: SSH UsePAM 未設為 yes。"
 
+    # TWGCB-01-012-0282: 停用 Kerberos 認證
+    grep -qE "^\s*KerberosAuthentication\s+no" "$SSHD_CONFIG" && print_pass "TWGCB-01-012-0282: SSH KerberosAuthentication 已設為 no。" || print_fail "TWGCB-01-012-0282: SSH KerberosAuthentication 未設為 no。"
+
+    # TWGCB-01-012-0283: SSH Banner
+    BANNER_LINE=$(grep -iE "^\s*Banner\s+" "$SSHD_CONFIG" | awk '{print $2}')
+    if [ -n "$BANNER_LINE" ] && [ "$BANNER_LINE" != "none" ] && [ -s "$BANNER_LINE" ]; then
+        print_pass "TWGCB-01-012-0283: SSH Banner 已設定 ($BANNER_LINE)。"
+    else
+        print_fail "TWGCB-01-012-0283: SSH Banner 未設定或檔案不存在。"
+    fi
+
+    # TWGCB-01-012-0315: 停用 GSSAPI 驗證
+    grep -qE "^\s*GSSAPIAuthentication\s+no" "$SSHD_CONFIG" && print_pass "TWGCB-01-012-0315: SSH GSSAPIAuthentication 已設為 no。" || print_fail "TWGCB-01-012-0315: SSH GSSAPIAuthentication 未設為 no。"
 }
 
 print_summary() {

--- a/GCB_SET/GCB_sshd.sh
+++ b/GCB_SET/GCB_sshd.sh
@@ -2,7 +2,9 @@
 
 #================================================================================
 # Red Hat Enterprise Linux 9 - SSH & PAM Government Configuration Baseline (GCB)
-# 文件版本: TWGCB-01-012 (v1.3)
+# 文件版本: TWGCB-01-012 (v1.2)
+# 來源: 國家資通安全研究院 (NICS) https://www.nics.nat.gov.tw/
+# 對應 NICS 公告日期: 中華民國114年6月12日 (2025-06-12)
 #
 # 新增功能 v3: 腳本啟動時自動備份 sshd_config 與 /etc/pam.d 目錄。
 # 新增功能 v2: 若 sshd 服務重啟失敗，將自動匯出狀態日誌以供除錯。
@@ -198,7 +200,24 @@ set_sshd_config "IgnoreUserKnownHosts" "yes"
 set_sshd_config "PrintLastLog" "yes"
 
 # TWGCB-01-012-0315: 停用 GSSAPI 驗證
-#set_sshd_config "GSSAPIAuthentication" "no"
+set_sshd_config "GSSAPIAuthentication" "no"
+
+# TWGCB-01-012-0282: 停用 Kerberos 認證
+set_sshd_config "KerberosAuthentication" "no"
+
+# TWGCB-01-012-0283: 設定 SSH Banner
+if [ ! -f /etc/issue.net ] || ! grep -q "Authorized" /etc/issue.net 2>/dev/null; then
+    cat > /etc/issue.net <<'BANNER'
+*****************************************************************
+                         Authorized Access Only
+  This system is restricted to authorized users for legitimate
+  business purposes. All activities may be monitored and recorded.
+*****************************************************************
+BANNER
+    chown root:root /etc/issue.net
+    chmod 644 /etc/issue.net
+fi
+set_sshd_config "Banner" "/etc/issue.net"
 
 # TWGCB-01-012-0284: 停用覆寫全系統加密原則
 echo "停用 SSH 覆寫全系統加密原則..."

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@
 
 **目的**：簡化並加速 Rocky Linux 9 系統的 GCB 安全性設定與檢測流程，透過自動化腳本減少人為疏失，確保設定一致性。
 
-**依據文件**：
-- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2
-- `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 v1.2
+**依據文件** (依據 [國家資通安全研究院 NICS](https://www.nics.nat.gov.tw/) 公告之最新版本)：
+- `TWGCB-01-012` Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) **v1.2** (公告日期：114/06/12)
+- `TWGCB-04-007` Apache HTTP Server 2.4 政府組態基準說明文件 **v1.2**
+
+> 規則對應更新時間：2026-06-07。下載連結請至 NICS 官網 `核心業務 → GCB → GCB說明文件` 取得。
 
 **核心特色**：
 - 🔍 **完整檢測**：全面掃描系統現狀與 GCB 規範的符合程度
@@ -337,7 +339,17 @@ sudo /usr/local/apache/bin/apachectl restart
 ---
 
 **維護者**：warden  
-**最後更新**：2025-01-15  
-**版本**：2.0
+**最後更新**：2026-06-07 (對應 NICS TWGCB-01-012 v1.2)  
+**版本**：2.1
+
+### 變更紀錄
+
+- **2026-06-07**：依據 NICS 公告之 TWGCB-01-012 v1.2 (114/06/12) 核對規則一致性
+  - 修正 `GCB_sshd.sh` 文件版本標示 (v1.3 → v1.2，RHEL 9 目前最新即為 v1.2)
+  - 啟用 `TWGCB-01-012-0315` GSSAPIAuthentication 預設停用
+  - 新增 `TWGCB-01-012-0282` KerberosAuthentication 停用設定
+  - 新增 `TWGCB-01-012-0283` SSH Banner 設定 (含 /etc/issue.net 預設內容)
+  - 檢測腳本補上 0282/0283/0315 對應檢查
+  - 檔案系統停用檢查改用對應 ID (0285-0300) 取代統一的 `XXXX` 佔位
 
 如有問題或建議，請透過 GitHub Issues 回報。


### PR DESCRIPTION
## Summary

依據 [國家資通安全研究院 NICS](https://www.nics.nat.gov.tw/) 官網公告核對 GCB 規則版本。

**確認結果**：RHEL 9 政府組態基準 `TWGCB-01-012` 目前最新版本為 **v1.2 (114/06/12 公告)**，與本專案 README 標示一致。NICS 官網目前並未發布 RHEL 9 的 v1.3 (僅 RHEL 8 `TWGCB-01-008` 有 v1.3)。

## Changes

### 修正版本標示錯誤
- `GCB_SET/GCB_sshd.sh` 標頭原為 `TWGCB-01-012 (v1.3)` → 修正為 `(v1.2)`，並補上 NICS 來源與公告日期

### 補上 v1.2 中既已存在但腳本未啟用的 SSH 項目
- **TWGCB-01-012-0315**：原本程式碼為註解狀態 `#set_sshd_config "GSSAPIAuthentication" "no"` → 啟用
- **TWGCB-01-012-0282**：補上 `KerberosAuthentication no`
- **TWGCB-01-012-0283**：補上 SSH `Banner /etc/issue.net` 與預設 banner 內容

### 檢測腳本對應補強
- `GCB_CHECK/GCB_check.sh` 新增 0282 / 0283 / 0315 對應檢測
- 檔案系統停用檢查從 `TWGCB-01-012-XXXX` 佔位改為各規則對應的具體 ID (0285-0300)
- `lsmod` 比對改用 `^${fs} ` 邊界避免誤判 (例：`ext` 不應匹配到 `ext4`)

### README
- 補上 NICS 來源連結與公告日期
- 新增 2026-06-07 變更紀錄段落

## Test plan

- [x] `bash -n` 語法檢查通過 (`GCB_check.sh`, `GCB_sshd.sh`, `GCB.sh`)
- [ ] 在 Rocky Linux 9 測試機上實際執行 `GCB_SET/GCB_sshd.sh`，確認 sshd 可順利重啟
- [ ] 在 Rocky Linux 9 測試機上執行 `GCB_CHECK/GCB_check.sh`，確認新加入的 0282/0283/0315 檢測結果正確

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmGNzFPZohXve7BVEX36Xm)_