### PR TITLE
GCB 規則對齊 TWGCB-01-012 v1.2 (1140612) 並修正既有檢測誤判

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
 # ==============================================================================
-# Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v2
+# Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v3
 #
-# 作者: warden
-# 日期: 2025-07-15
+# 文件依據: TWGCB-01-012 v1.2 (1140612, 2025-06-12 發行)
 #
-# 功能更新:
+# 功能更新 v3:
+# 1. 修正模組停用檢查邏輯 (原本反向, 已合規系統會被判 FAIL)
+# 2. 將 v1.1 新增之檔案系統項目 (0285-0300) 之 placeholder ID 補齊
+# 3. TMOUT 檢查擴增至 /etc/profile.d/ 目錄 (與 GCB.sh 之設定路徑一致)
+# 4. 防呆: pwquality / faillock / login.defs 之數值欄位為空時不再噴錯
+#
+# 功能更新 v2:
 # 1. 新增日誌匯出功能至 /var/log/
 # 2. 針對 TWGCB-01-012-0063 項目新增檔案數量統計
 # 3. 新增 CLI 統計摘要 (通過/未通過數量與比率)
@@ -91,6 +96,35 @@ if [[ $EUID -ne 0 ]]; then
    print_fail "此腳本需要 root 權限才能完整執行。請使用 'sudo ./check_rhel9_gcb.sh' 執行。"
 fi
 
+# 判斷核心模組是否「已被 GCB 停用」:
+#   - /etc/modprobe.d/*.conf 內含 "install <mod> /bin/true" (或 /bin/false), 或
+#   - 系統根本沒有此模組 (modprobe -n -v 找不到), 且
+#   - 模組目前並未被載入 (lsmod 找不到)
+# 同時回傳 0 (合規) 或 1 (未合規)。
+is_module_disabled() {
+    local mod="$1"
+    local probe
+    probe=$(modprobe -n -v "$mod" 2>&1)
+
+    local declared=1
+    if echo "$probe" | grep -qE "install[[:space:]]+/bin/(true|false)"; then
+        declared=0
+    elif echo "$probe" | grep -qiE "not found|FATAL|無此模組|沒有.*模組"; then
+        # 系統不提供此模組視同已停用
+        declared=0
+    fi
+
+    local loaded=1
+    if lsmod | awk '{print $1}' | grep -qx "${mod//-/_}"; then
+        loaded=0
+    fi
+
+    if [ "$declared" -eq 0 ] && [ "$loaded" -ne 0 ]; then
+        return 0
+    fi
+    return 1
+}
+
 # ==============================================================================
 # --- 檢測函式 ---
 # ==============================================================================
@@ -100,21 +134,21 @@ check_filesystem() {
     print_header "磁碟與檔案系統 (1/3)"
 
     # TWGCB-01-012-0001: 停用 cramfs 檔案系統
-    if ! modprobe -n -v cramfs | grep -q "install /bin/true" && ! lsmod | grep -q "cramfs"; then
+    if is_module_disabled cramfs; then
         print_pass "TWGCB-01-012-0001: cramfs 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0001: cramfs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     # TWGCB-01-012-0002: 停用 squashfs 檔案系統
-    if ! modprobe -n -v squashfs | grep -q "install /bin/true" && ! lsmod | grep -q "squashfs"; then
+    if is_module_disabled squashfs; then
         print_pass "TWGCB-01-012-0002: squashfs 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0002: squashfs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     # TWGCB-01-012-0003: 停用 udf 檔案系統
-    if ! modprobe -n -v udf | grep -q "install /bin/true" && ! lsmod | grep -q "udf"; then
+    if is_module_disabled udf; then
         print_pass "TWGCB-01-012-0003: udf 檔案系統已停用。"
     else
         print_fail "TWGCB-01-012-0003: udf 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
@@ -171,21 +205,39 @@ check_filesystem() {
     fi
 
     # TWGCB-01-012-0031: 停用 USB 儲存裝置
-    if ! modprobe -n -v usb-storage | grep -q "install /bin/true" && ! lsmod | grep -q "usb_storage"; then
+    if is_module_disabled usb-storage; then
         print_pass "TWGCB-01-012-0031: USB 儲存裝置已停用。"
     else
         print_fail "TWGCB-01-012-0031: USB 儲存裝置未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
     fi
 
     print_header "磁碟與檔案系統 (3/3)"
-    # 新增項目檢查 from v1.1
-    # TWGCB-01-012-0285 to 0297, 0299-0300: 停用各種檔案系統
-    FS_TO_DISABLE=(freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfsd)
-    for fs in "${FS_TO_DISABLE[@]}"; do
-        if ! modprobe -n -v "$fs" | grep -q "install /bin/true" && ! lsmod | grep -q "$fs"; then
-            print_pass "TWGCB-01-012-XXXX: $fs 檔案系統已停用。"
+    # v1.1 新增之檔案系統停用項目 (TWGCB-01-012-0285 ~ 0300)
+    # 與 GCB_SET/GCB.sh 之 apply_disk_and_fs_settings 對齊
+    declare -A FS_TWGCB_ID=(
+        [freevxfs]="TWGCB-01-012-0285"
+        [hfs]="TWGCB-01-012-0286"
+        [hfsplus]="TWGCB-01-012-0287"
+        [jffs2]="TWGCB-01-012-0288"
+        [afs]="TWGCB-01-012-0289"
+        [ceph]="TWGCB-01-012-0290"
+        [cifs]="TWGCB-01-012-0291"
+        [exfat]="TWGCB-01-012-0292"
+        [ext]="TWGCB-01-012-0293"
+        [fat]="TWGCB-01-012-0294"
+        [fscache]="TWGCB-01-012-0295"
+        [fuse]="TWGCB-01-012-0296"
+        [gfs2]="TWGCB-01-012-0297"
+        [nfs_common]="TWGCB-01-012-0298"
+        [nfsd]="TWGCB-01-012-0299"
+        [smbfs_common]="TWGCB-01-012-0300"
+    )
+    for fs in freevxfs hfs hfsplus jffs2 afs ceph cifs exfat ext fat fscache fuse gfs2 nfs_common nfsd smbfs_common; do
+        local id="${FS_TWGCB_ID[$fs]}"
+        if is_module_disabled "$fs"; then
+            print_pass "${id}: $fs 檔案系統已停用。"
         else
-            print_fail "TWGCB-01-012-XXXX: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
+            print_fail "${id}: $fs 檔案系統未停用。應在 /etc/modprobe.d/ 建立設定檔停用。"
         fi
     done
 }
@@ -411,62 +463,65 @@ check_accounts() {
     print_header "帳號與存取控制 (1/2)"
     
     # TWGCB-01-012-0207: 通行碼最小長度
-    MINLEN=$(grep '^\s*minlen' /etc/security/pwquality.conf | awk -F= '{print $2}' | xargs)
-    if [[ "$MINLEN" -ge 12 ]]; then
+    MINLEN=$(grep '^\s*minlen' /etc/security/pwquality.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$MINLEN" && "$MINLEN" =~ ^[0-9]+$ && "$MINLEN" -ge 12 ]]; then
         print_pass "TWGCB-01-012-0207: 通行碼最小長度 (minlen) 為 $MINLEN，符合 >= 12 要求。"
     else
-        print_fail "TWGCB-01-012-0207: 通行碼最小長度 (minlen) 為 $MINLEN，應 >= 12。"
+        print_fail "TWGCB-01-012-0207: 通行碼最小長度 (minlen) 為 ${MINLEN:-未設定}，應 >= 12。"
     fi
 
     # TWGCB-01-012-0208: 通行碼字元類別數量
-    MINCLASS=$(grep '^\s*minclass' /etc/security/pwquality.conf | awk -F= '{print $2}' | xargs)
-    if [[ "$MINCLASS" -ge 4 ]]; then
+    MINCLASS=$(grep '^\s*minclass' /etc/security/pwquality.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$MINCLASS" && "$MINCLASS" =~ ^[0-9]+$ && "$MINCLASS" -ge 4 ]]; then
         print_pass "TWGCB-01-012-0208: 通行碼字元類別數 (minclass) 為 $MINCLASS，符合 >= 4 要求。"
     else
-        print_fail "TWGCB-01-012-0208: 通行碼字元類別數 (minclass) 為 $MINCLASS，應 >= 4。"
+        print_fail "TWGCB-01-012-0208: 通行碼字元類別數 (minclass) 為 ${MINCLASS:-未設定}，應 >= 4。"
     fi
 
     # TWGCB-01-012-0218: 帳戶鎖定閾值
-    DENY=$(grep '^\s*deny' /etc/security/faillock.conf | awk -F= '{print $2}' | xargs)
-    if [[ "$DENY" -gt 0 && "$DENY" -le 5 ]]; then
+    DENY=$(grep '^\s*deny' /etc/security/faillock.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$DENY" && "$DENY" =~ ^[0-9]+$ && "$DENY" -gt 0 && "$DENY" -le 5 ]]; then
         print_pass "TWGCB-01-012-0218: 帳戶鎖定閾值 (deny) 為 $DENY，符合 1-5 次要求。"
     else
-        print_fail "TWGCB-01-012-0218: 帳戶鎖定閾值 (deny) 為 $DENY，應設定為 1-5 次。"
+        print_fail "TWGCB-01-012-0218: 帳戶鎖定閾值 (deny) 為 ${DENY:-未設定}，應設定為 1-5 次。"
     fi
-    
+
     # TWGCB-01-012-0219: 帳戶鎖定時間
-    UNLOCK_TIME=$(grep '^\s*unlock_time' /etc/security/faillock.conf | awk -F= '{print $2}' | xargs)
-    if [[ "$UNLOCK_TIME" -ge 900 ]]; then
+    UNLOCK_TIME=$(grep '^\s*unlock_time' /etc/security/faillock.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$UNLOCK_TIME" && "$UNLOCK_TIME" =~ ^[0-9]+$ && "$UNLOCK_TIME" -ge 900 ]]; then
         print_pass "TWGCB-01-012-0219: 帳戶鎖定時間 (unlock_time) 為 $UNLOCK_TIME 秒，符合 >= 900 要求。"
     else
-        print_fail "TWGCB-01-012-0219: 帳戶鎖定時間 (unlock_time) 為 $UNLOCK_TIME 秒，應 >= 900。"
+        print_fail "TWGCB-01-012-0219: 帳戶鎖定時間 (unlock_time) 為 ${UNLOCK_TIME:-未設定} 秒，應 >= 900。"
     fi
 
     print_header "帳號與存取控制 (2/2)"
     # TWGCB-01-012-0222: 通行碼最短使用期限
-    PASS_MIN_DAYS=$(grep '^\s*PASS_MIN_DAYS' /etc/login.defs | awk '{print $2}')
-    if [[ "$PASS_MIN_DAYS" -ge 1 ]]; then
+    PASS_MIN_DAYS=$(grep '^\s*PASS_MIN_DAYS' /etc/login.defs 2>/dev/null | awk '{print $2}')
+    if [[ -n "$PASS_MIN_DAYS" && "$PASS_MIN_DAYS" =~ ^[0-9]+$ && "$PASS_MIN_DAYS" -ge 1 ]]; then
         print_pass "TWGCB-01-012-0222: 通行碼最短使用期限為 $PASS_MIN_DAYS 天，符合 >= 1 要求。"
     else
-        print_fail "TWGCB-01-012-0222: 通行碼最短使用期限為 $PASS_MIN_DAYS 天，應 >= 1。"
+        print_fail "TWGCB-01-012-0222: 通行碼最短使用期限為 ${PASS_MIN_DAYS:-未設定} 天，應 >= 1。"
     fi
     print_info "TWGCB-01-012-0222: 提醒：此設定對既有使用者需使用 'chage' 指令個別設定。"
 
     # TWGCB-01-012-0224: 通行碼最長使用期限
-    PASS_MAX_DAYS=$(grep '^\s*PASS_MAX_DAYS' /etc/login.defs | awk '{print $2}')
-    if [[ "$PASS_MAX_DAYS" -le 90 && "$PASS_MAX_DAYS" -gt 0 ]]; then
+    PASS_MAX_DAYS=$(grep '^\s*PASS_MAX_DAYS' /etc/login.defs 2>/dev/null | awk '{print $2}')
+    if [[ -n "$PASS_MAX_DAYS" && "$PASS_MAX_DAYS" =~ ^[0-9]+$ && "$PASS_MAX_DAYS" -le 90 && "$PASS_MAX_DAYS" -gt 0 ]]; then
         print_pass "TWGCB-01-012-0224: 通行碼最長使用期限為 $PASS_MAX_DAYS 天，符合 1-90 天要求。"
     else
-        print_fail "TWGCB-01-012-0224: 通行碼最長使用期限為 $PASS_MAX_DAYS 天，應設定在 1-90 天內。"
+        print_fail "TWGCB-01-012-0224: 通行碼最長使用期限為 ${PASS_MAX_DAYS:-未設定} 天，應設定在 1-90 天內。"
     fi
     print_info "TWGCB-01-012-0224: 提醒：此設定對既有使用者需使用 'chage' 指令個別設定。"
 
     # TWGCB-01-012-0235: Bash shell 閒置登出時間
-    TMOUT_VAL=$(grep -E '^\s*readonly TMOUT=' /etc/profile /etc/bashrc 2>/dev/null | tail -1 | grep -o '[0-9]*')
-    if [[ "$TMOUT_VAL" -gt 0 && "$TMOUT_VAL" -le 900 ]]; then
+    # 設定可能存在 /etc/profile、/etc/bashrc 或 /etc/profile.d/*.sh
+    TMOUT_VAL=$(grep -hE '^\s*(readonly\s+)?TMOUT=' \
+        /etc/profile /etc/bashrc /etc/profile.d/*.sh 2>/dev/null \
+        | grep -oE 'TMOUT=[0-9]+' | tail -1 | grep -oE '[0-9]+')
+    if [[ -n "$TMOUT_VAL" && "$TMOUT_VAL" -gt 0 && "$TMOUT_VAL" -le 900 ]]; then
         print_pass "TWGCB-01-012-0235: Bash shell 閒置登出時間為 $TMOUT_VAL 秒，符合 1-900 秒要求。"
     else
-        print_fail "TWGCB-01-012-0235: Bash shell 閒置登出時間未設定或不符要求 (目前: $TMOUT_VAL)，應設定在 1-900 秒內。"
+        print_fail "TWGCB-01-012-0235: Bash shell 閒置登出時間未設定或不符要求 (目前: ${TMOUT_VAL:-未設定})，應設定在 1-900 秒內。"
     fi
 
     # TWGCB-01-012-0238: 使用者帳號預設 umask
@@ -496,10 +551,10 @@ check_ssh() {
 
     # TWGCB-01-012-0266: SSH MaxAuthTries
     MAX_AUTH_TRIES=$(grep -iE "^\s*MaxAuthTries" "$SSHD_CONFIG" | awk '{print $2}')
-    if [[ "$MAX_AUTH_TRIES" -gt 0 && "$MAX_AUTH_TRIES" -le 4 ]]; then
+    if [[ -n "$MAX_AUTH_TRIES" && "$MAX_AUTH_TRIES" =~ ^[0-9]+$ && "$MAX_AUTH_TRIES" -gt 0 && "$MAX_AUTH_TRIES" -le 4 ]]; then
         print_pass "TWGCB-01-012-0266: SSH MaxAuthTries 為 $MAX_AUTH_TRIES，符合 1-4 次要求。"
     else
-        print_fail "TWGCB-01-012-0266: SSH MaxAuthTries 為 $MAX_AUTH_TRIES，應為 1-4 次。"
+        print_fail "TWGCB-01-012-0266: SSH MaxAuthTries 為 ${MAX_AUTH_TRIES:-未設定}，應為 1-4 次。"
     fi
 
     # TWGCB-01-012-0269: SSH PermitRootLogin
@@ -511,10 +566,12 @@ check_ssh() {
     # TWGCB-01-012-0272: SSH 逾時時間 (v1.2 修改)
     ALIVE_INTERVAL=$(grep -iE "^\s*ClientAliveInterval" "$SSHD_CONFIG" | awk '{print $2}')
     ALIVE_COUNT_MAX=$(grep -iE "^\s*ClientAliveCountMax" "$SSHD_CONFIG" | awk '{print $2}')
-    if [[ "$ALIVE_INTERVAL" -gt 0 && "$ALIVE_INTERVAL" -le 600 && "$ALIVE_COUNT_MAX" -eq 1 ]]; then
+    if [[ -n "$ALIVE_INTERVAL" && -n "$ALIVE_COUNT_MAX" \
+          && "$ALIVE_INTERVAL" =~ ^[0-9]+$ && "$ALIVE_COUNT_MAX" =~ ^[0-9]+$ \
+          && "$ALIVE_INTERVAL" -gt 0 && "$ALIVE_INTERVAL" -le 600 && "$ALIVE_COUNT_MAX" -eq 1 ]]; then
         print_pass "TWGCB-01-012-0272: SSH 逾時時間設定符合要求 (Interval: $ALIVE_INTERVAL, CountMax: $ALIVE_COUNT_MAX)。"
     else
-        print_fail "TWGCB-01-012-0272: SSH 逾時時間設定不符要求 (Interval: $ALIVE_INTERVAL, CountMax: $ALIVE_COUNT_MAX)。應為 Interval <= 600 且 CountMax = 1。"
+        print_fail "TWGCB-01-012-0272: SSH 逾時時間設定不符要求 (Interval: ${ALIVE_INTERVAL:-未設定}, CountMax: ${ALIVE_COUNT_MAX:-未設定})。應為 Interval <= 600 且 CountMax = 1。"
     fi
 
     # TWGCB-01-012-0274: SSH UsePAM

--- a/GCB_SET/GCB_sshd.sh
+++ b/GCB_SET/GCB_sshd.sh
@@ -2,8 +2,9 @@
 
 #================================================================================
 # Red Hat Enterprise Linux 9 - SSH & PAM Government Configuration Baseline (GCB)
-# 文件版本: TWGCB-01-012 (v1.3)
+# 文件依據: TWGCB-01-012 v1.2 (1140612, 2025-06-12 發行)
 #
+# 新增功能 v4: 套用 TWGCB-01-012-0315 (GSSAPIAuthentication=no)
 # 新增功能 v3: 腳本啟動時自動備份 sshd_config 與 /etc/pam.d 目錄。
 # 新增功能 v2: 若 sshd 服務重啟失敗，將自動匯出狀態日誌以供除錯。
 #
@@ -198,7 +199,7 @@ set_sshd_config "IgnoreUserKnownHosts" "yes"
 set_sshd_config "PrintLastLog" "yes"
 
 # TWGCB-01-012-0315: 停用 GSSAPI 驗證
-#set_sshd_config "GSSAPIAuthentication" "no"
+set_sshd_config "GSSAPIAuthentication" "no"
 
 # TWGCB-01-012-0284: 停用覆寫全系統加密原則
 echo "停用 SSH 覆寫全系統加密原則..."


### PR DESCRIPTION
## Summary

依照 NICS 國家資通安全研究院 ([nics.nat.gov.tw](https://www.nics.nat.gov.tw/)) 目前最新公告之 **TWGCB-01-012 v1.2 (1140612 / 2025-06-12)** 與 **TWGCB-04-007 v1.2** 比對, 文件版本與專案目前所對齊的版本一致 (沒有新版可升), 但檢視程式碼後發現多個既有 bug 會使檢測結果不準, 一併在本 PR 修正。

### NICS 文件版本確認

| 規範 | 最新版本 | 公告日期 | 專案現況 |
| --- | --- | --- | --- |
| TWGCB-01-012 (RHEL 9 Server) | v1.2 | 1140612 (2025-06-12) | ✅ 已對齊 |
| TWGCB-04-007 (Apache 2.4) | v1.2 | 1111226 (2022-12-26) | ✅ 已對齊 |
| TWGCB-01-008 (RHEL 8) | v1.3 | 1140610 (2025-06-10) | — (本專案範圍外) |

### 修正內容

**`GCB_CHECK/GCB_check.sh`**

- **修正模組停用檢查反向邏輯** (高優先) — 原本的 `! modprobe -n -v X | grep -q "install /bin/true"` 會把**已正確停用**的系統判 `FAIL`、把**未停用**的系統判 `PASS`, 與規範語意完全顛倒。改以共用 helper `is_module_disabled` 同時判讀 modprobe.d 設定、模組是否存在於系統及 `lsmod` 載入狀態, 影響項目: `TWGCB-01-012-0001/0002/0003/0031` 與 v1.1 新增之 `0285~0300`。
- **補齊 placeholder ID** — `TWGCB-01-012-XXXX` 改為 `0285~0300`, 與 `GCB_SET/GCB.sh` 中的設定動作 ID 一一對應。
- **TMOUT (0235) 檢查路徑修正** — 原本只看 `/etc/profile` 與 `/etc/bashrc`, 但 `GCB.sh` 是寫入 `/etc/profile.d/gcb-timeout.sh`, 導致正確設定也會被判 FAIL。擴及 `/etc/profile.d/*.sh`。
- **數值欄位防呆** — `pwquality`、`faillock`、`login.defs`、`sshd_config` 之數值讀取若該檔不存在或欄位未設定, 原本會噴 `bash: [[: : integer expression expected` 並終止當段檢查。增加空值與 `^[0-9]+$` 檢查。

**`GCB_SET/GCB_sshd.sh`**

- 修正檔頭文件版本 — 原誤標 `TWGCB-01-012 (v1.3)`, 該版本不存在; 改為對齊最新 v1.2 (1140612)。
- 啟用 `TWGCB-01-012-0315 GSSAPIAuthentication=no` (原本被註解掉)。

## Test plan

- [ ] 在乾淨 Rocky Linux 9 / RHEL 9 主機上執行 `sudo ./GCB_CHECK/GCB_check.sh`, 確認未設定模組停用前所有 `0001/0002/0003/0031/0285~0300` 都判 `FAIL`。
- [ ] 執行 `sudo ./GCB_SET/GCB.sh` 後再跑 `GCB_check.sh`, 確認上述項目改判 `PASS` (重開機後生效)。
- [ ] 確認 TMOUT 設定寫入 `/etc/profile.d/gcb-timeout.sh` 後 `0235` 改判 `PASS`。
- [ ] 在 `/etc/security/pwquality.conf` 全空的狀態下執行檢測, 確認不再噴 `integer expression expected`。
- [ ] 執行 `sudo ./GCB_SET/GCB_sshd.sh` 後檢查 `/etc/ssh/sshd_config`, 確認 `GSSAPIAuthentication no` 存在。

## 參考來源

- [國家資通安全研究院 - GCB 說明文件](https://www.nics.nat.gov.tw/core_business/cybersecurity_defense/GCB/GCB_Documentation/)
- `[TWGCB-01-012 RHEL 9 (伺服器) v1.2](https://download.nics.nat.gov.tw/api/v4/file-service/UploadFile/attachfilegcb/TWGCB-01-012_Red%20Hat%20Enterprise%20Linux%209%E6%94%BF%E5%BA%9C%E7%B5%84%E6%85%8B%E5%9F%BA%E6%BA%96%E8%AA%AA%E6%98%8E%E6%96%87%E4%BB%B6(%E4%BC%BA%E6%9C%8D%E5%99%A8)v1.2_1140612.pdf)`
- [行政院國家資通安全會報技術服務中心 GCB 專區](https://www.nccst.nat.gov.tw/GCB)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GDwV9bJv4FxZpAcjktxL1p)_