### PR TITLE
fix: 修正 GCB_sshd.sh 版本標示為 TWGCB-01-012 v1.2

### DIFF
--- a/GCB_SET/GCB_sshd.sh
+++ b/GCB_SET/GCB_sshd.sh
@@ -2,7 +2,7 @@
 
 #================================================================================
 # Red Hat Enterprise Linux 9 - SSH & PAM Government Configuration Baseline (GCB)
-# 文件版本: TWGCB-01-012 (v1.3)
+# 文件版本: TWGCB-01-012 (v1.2)
 #
 # 新增功能 v3: 腳本啟動時自動備份 sshd_config 與 /etc/pam.d 目錄。
 # 新增功能 v2: 若 sshd 服務重啟失敗，將自動匯出狀態日誌以供除錯。


### PR DESCRIPTION
## Summary

根據國家資通安全研究院 (NICS) 公告，**TWGCB-01-012 Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) 目前最新版本為 v1.2**（民國 114/6/10 發布）。

`GCB_SET/GCB_sshd.sh` 第 5 行原本誤標為 `v1.3`（該版本實際上不存在），其他檔案 (`README.md`、`GCB.sh`、`GCB_check.sh`) 均已正確標示 v1.2，此次將 sshd 腳本一併對齊。

## 背景：嘗試存取 NICS 網站之限制

- 本 session 嘗試從 `https://www.nics.nat.gov.tw/` 與 `https://download.nics.nat.gov.tw/` 直接下載最新 GCB PDF
- 兩者皆回應 **HTTP 403 Forbidden** (推測為地理／防火牆限制，本沙箱環境無法存取)
- 透過網路搜尋確認最新版本資訊：
  - **TWGCB-01-012 (RHEL 9 伺服器)**：v1.2 (114/6/10)
    - v1.1 → 新增 31 項、修改 2 項、刪除 1 項
    - v1.2 → 修改 1 項
  - **TWGCB-04-007 (Apache 2.4)**：v1.2

## 後續建議 (本 PR 範圍外)

若需要實際對齊 v1.1 / v1.2 異動之 31 項新增與 3 項修改／刪除項目，建議：
1. 由使用者下載 GCB PDF 並提供文件附件 1、附件 2 之 TWGCB-ID 清單
2. 或將 PDF 上傳至 repo 後再由 Claude 解析、補充對應規則
3. 目前所有腳本已涵蓋約 146 (`GCB.sh`) + 30 (`GCB_sshd.sh`) + 61 (`GCB_check.sh`) 個 TWGCB-ID 項目

## Test plan

- [ ] 確認 `GCB_SET/GCB_sshd.sh` 標頭版本為 `v1.2`
- [ ] 確認其他腳本檔案版本標示一致
- [ ] 在測試環境執行腳本，確認行為無異常

https://claude.ai/code/session_011umHtYWxbyQWzcSZUbhRrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011umHtYWxbyQWzcSZUbhRrJ)_