### PR TITLE
補實 TWGCB-01-012 v1.2 檢測項目 (對齊 NICS 最新版本)

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -4,7 +4,7 @@
 # Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v3
 #
 # 作者: warden
-# 日期: 2026-06-15
+# 日期: 2026-06-17
 #
 # 功能更新:
 # 1. 新增日誌匯出功能至 /var/log/
@@ -15,6 +15,13 @@
 #    - 新增 sudo 相關檢查 (0033, 0034, 0035)
 #    - 新增 v1.2 新增項目：opasswd 權限 (0303, 0304)、/etc/shells nologin (0305)、
 #      chrony 非 root 執行 (0306)、ptrace 限制模式 (0307)
+# 5. v3.1 補齊 README v2.1 異動紀錄中未實作之檢測項目 (2026-06-17)：
+#    - 0255 SSH Protocol 檢查相容 OpenSSH 7.4+ (未設定視為預設 2)
+#    - 0235 TMOUT / 0238 umask 涵蓋 /etc/profile.d/*.sh 與 /etc/login.defs
+#    - 新增 0221 通行碼 SHA512 雜湊檢查
+#    - 新增 0310 even_deny_root 檢查
+#    - 新增 0311 maxsequence 檢查
+#    - 新增 check_cron 函式：0189、0190/91、0192~0201、0202/03 cron / at 權限
 #
 # 來源依據：
 #   國家資通安全研究院 (NICS) TWGCB-01-012 v1.2 (中華民國114年6月12日)
@@ -551,19 +558,106 @@ check_accounts() {
     print_info "TWGCB-01-012-0224: 提醒：此設定對既有使用者需使用 'chage' 指令個別設定。"
 
     # TWGCB-01-012-0235: Bash shell 閒置登出時間
-    TMOUT_VAL=$(grep -E '^\s*readonly TMOUT=' /etc/profile /etc/bashrc 2>/dev/null | tail -1 | grep -o '[0-9]*')
-    if [[ "$TMOUT_VAL" -gt 0 && "$TMOUT_VAL" -le 900 ]]; then
+    # 涵蓋 /etc/profile、/etc/bashrc 與 /etc/profile.d/*.sh
+    TMOUT_VAL=$(grep -hE '^\s*(readonly\s+)?TMOUT=' /etc/profile /etc/bashrc /etc/profile.d/*.sh 2>/dev/null \
+        | grep -oE 'TMOUT=[0-9]+' | tail -1 | cut -d= -f2)
+    if [[ -n "$TMOUT_VAL" && "$TMOUT_VAL" -gt 0 && "$TMOUT_VAL" -le 900 ]]; then
         print_pass "TWGCB-01-012-0235: Bash shell 閒置登出時間為 $TMOUT_VAL 秒，符合 1-900 秒要求。"
     else
-        print_fail "TWGCB-01-012-0235: Bash shell 閒置登出時間未設定或不符要求 (目前: $TMOUT_VAL)，應設定在 1-900 秒內。"
+        print_fail "TWGCB-01-012-0235: Bash shell 閒置登出時間未設定或不符要求 (目前: ${TMOUT_VAL:-未設定})，應於 /etc/profile、/etc/bashrc 或 /etc/profile.d/*.sh 設定 1-900 秒內。"
     fi
 
     # TWGCB-01-012-0238: 使用者帳號預設 umask
-    UMASK_VAL=$(grep '^\s*umask' /etc/profile /etc/bashrc | tail -n1 | awk '{print $2}')
-    if [[ "$UMASK_VAL" == "027" || "$UMASK_VAL" == "077" ]]; then
-        print_pass "TWGCB-01-012-0238: 使用者預設 umask 為 $UMASK_VAL，符合 027 或更嚴格要求。"
+    # 涵蓋 /etc/profile、/etc/bashrc、/etc/profile.d/*.sh 與 /etc/login.defs (UMASK 指令)
+    UMASK_VAL=$(grep -hE '^\s*umask\s+[0-7]+' /etc/profile /etc/bashrc /etc/profile.d/*.sh 2>/dev/null \
+        | awk '{print $2}' | tail -n1)
+    LOGINDEFS_UMASK=$(grep -hE '^\s*UMASK\s+[0-7]+' /etc/login.defs 2>/dev/null | awk '{print $2}' | tail -n1)
+    UMASK_OK=0
+    [[ "$UMASK_VAL" == "027" || "$UMASK_VAL" == "077" ]] && UMASK_OK=1
+    [[ "$LOGINDEFS_UMASK" == "027" || "$LOGINDEFS_UMASK" == "077" ]] && UMASK_OK=1
+    if [[ "$UMASK_OK" -eq 1 ]]; then
+        print_pass "TWGCB-01-012-0238: 使用者預設 umask 符合要求 (profile=${UMASK_VAL:-N/A}, login.defs=${LOGINDEFS_UMASK:-N/A})。"
     else
-        print_fail "TWGCB-01-012-0238: 使用者預設 umask 為 $UMASK_VAL，應為 027 或更嚴格。"
+        print_fail "TWGCB-01-012-0238: 使用者預設 umask 不符要求 (profile=${UMASK_VAL:-未設定}, login.defs=${LOGINDEFS_UMASK:-未設定})，應為 027 或更嚴格。"
+    fi
+
+    # TWGCB-01-012-0221: 通行碼雜湊演算法為 SHA512
+    ENCRYPT_METHOD=$(grep -E '^\s*ENCRYPT_METHOD\s+' /etc/login.defs 2>/dev/null | awk '{print $2}' | tail -n1)
+    PAM_SHA512_OK=0
+    if grep -qE '^\s*password\s+(sufficient|required)\s+pam_unix\.so.*sha512' /etc/pam.d/system-auth /etc/pam.d/password-auth 2>/dev/null; then
+        PAM_SHA512_OK=1
+    fi
+    if [[ "$ENCRYPT_METHOD" == "SHA512" && "$PAM_SHA512_OK" -eq 1 ]]; then
+        print_pass "TWGCB-01-012-0221: 通行碼雜湊演算法已設為 SHA512 (login.defs 與 PAM 皆已設定)。"
+    elif [[ "$ENCRYPT_METHOD" == "SHA512" ]]; then
+        print_fail "TWGCB-01-012-0221: login.defs 已設定 SHA512，但 system-auth/password-auth 未含 sha512 選項。"
+    else
+        print_fail "TWGCB-01-012-0221: 通行碼雜湊演算法不符 (login.defs=${ENCRYPT_METHOD:-未設定})，應為 SHA512。"
+    fi
+
+    # TWGCB-01-012-0310: faillock 應對 root 套用 (even_deny_root)
+    if grep -qE '^\s*even_deny_root' /etc/security/faillock.conf 2>/dev/null; then
+        print_pass "TWGCB-01-012-0310: faillock.conf 已設定 even_deny_root，鎖定亦適用於 root。"
+    else
+        print_fail "TWGCB-01-012-0310: faillock.conf 未設定 even_deny_root，應加入該設定以涵蓋 root 帳號。"
+    fi
+
+    # TWGCB-01-012-0311: 通行碼字元連續序列上限 (maxsequence)
+    MAXSEQ=$(grep -E '^\s*maxsequence\s*=' /etc/security/pwquality.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$MAXSEQ" && "$MAXSEQ" -ge 1 && "$MAXSEQ" -le 3 ]]; then
+        print_pass "TWGCB-01-012-0311: pwquality.conf maxsequence 為 $MAXSEQ，符合 1-3 要求。"
+    else
+        print_fail "TWGCB-01-012-0311: pwquality.conf maxsequence 為 ${MAXSEQ:-未設定}，應設為 1-3。"
+    fi
+}
+
+# Cron / At 相關檢查 (TWGCB-01-012-0189 ~ 0203)
+check_cron() {
+    print_header "Cron 與 At 任務排程"
+
+    # TWGCB-01-012-0189: crond 服務應啟用
+    if systemctl is-enabled crond &>/dev/null && systemctl is-active crond &>/dev/null; then
+        print_pass "TWGCB-01-012-0189: crond 服務已啟用並執行中。"
+    else
+        print_fail "TWGCB-01-012-0189: crond 服務未啟用或未執行。"
+    fi
+
+    # TWGCB-01-012-0190 & 0191: /etc/crontab 擁有者與權限
+    if [ -f /etc/crontab ]; then
+        check_file_perms_owner "TWGCB-01-012-0190/91" "/etc/crontab" "600" "root:root"
+    else
+        print_info "TWGCB-01-012-0190/91: /etc/crontab 不存在，無法檢查。"
+    fi
+
+    # TWGCB-01-012-0192 ~ 0201: cron 目錄擁有者與權限
+    declare -A CRON_DIR_IDS=(
+        ["0192/93"]="/etc/cron.hourly"
+        ["0194/95"]="/etc/cron.daily"
+        ["0196/97"]="/etc/cron.weekly"
+        ["0198/99"]="/etc/cron.monthly"
+        ["0200/01"]="/etc/cron.d"
+    )
+    for id in $(echo "${!CRON_DIR_IDS[@]}" | tr ' ' '\n' | sort); do
+        dir="${CRON_DIR_IDS[$id]}"
+        if [ -d "$dir" ]; then
+            check_file_perms_owner "TWGCB-01-012-${id}" "$dir" "700" "root:root"
+        else
+            print_info "TWGCB-01-012-${id}: $dir 不存在，無法檢查。"
+        fi
+    done
+
+    # TWGCB-01-012-0202: 限制 cron 使用者 (/etc/cron.allow 應存在且 /etc/cron.deny 不應存在)
+    if [ ! -e /etc/cron.deny ] && [ -f /etc/cron.allow ]; then
+        check_file_perms_owner "TWGCB-01-012-0202" "/etc/cron.allow" "600" "root:root"
+    else
+        print_fail "TWGCB-01-012-0202: cron 使用者限制不符。應移除 /etc/cron.deny 並建立 /etc/cron.allow (root:root, 600)。"
+    fi
+
+    # TWGCB-01-012-0203: 限制 at 使用者 (/etc/at.allow 應存在且 /etc/at.deny 不應存在)
+    if [ ! -e /etc/at.deny ] && [ -f /etc/at.allow ]; then
+        check_file_perms_owner "TWGCB-01-012-0203" "/etc/at.allow" "600" "root:root"
+    else
+        print_fail "TWGCB-01-012-0203: at 使用者限制不符。應移除 /etc/at.deny 並建立 /etc/at.allow (root:root, 600)。"
     fi
 }
 
@@ -578,7 +672,15 @@ check_ssh() {
     fi
     
     # TWGCB-01-012-0255: SSH 協定版本
-    grep -qE "^\s*Protocol\s+2" "$SSHD_CONFIG" && print_pass "TWGCB-01-012-0255: SSH 協定版本已設為 2。" || print_fail "TWGCB-01-012-0255: SSH 協定版本未設為 2。"
+    # OpenSSH 7.4+ 已移除 Protocol 指令，預設僅支援 Protocol 2，視為合規。
+    if grep -qE "^\s*Protocol\s+1" "$SSHD_CONFIG"; then
+        print_fail "TWGCB-01-012-0255: SSH 協定版本明確設為 1，應改為 2 或移除該設定。"
+    elif grep -qE "^\s*Protocol\s+2" "$SSHD_CONFIG"; then
+        print_pass "TWGCB-01-012-0255: SSH 協定版本已明確設為 2。"
+    else
+        SSHD_VER=$(ssh -V 2>&1 | awk '{print $1}')
+        print_pass "TWGCB-01-012-0255: 未設定 Protocol，OpenSSH 7.4+ 預設僅支援 Protocol 2 (${SSHD_VER:-未知版本})。"
+    fi
 
     # TWGCB-01-012-0256 & 0257: sshd_config 檔案權限
     check_file_perms_owner "TWGCB-01-012-0256/57" "$SSHD_CONFIG" "600" "root:root"
@@ -652,6 +754,7 @@ main() {
     check_software
     check_network
     check_selinux
+    check_cron
     check_accounts
     check_ssh
 

--- a/README.md
+++ b/README.md
@@ -337,20 +337,24 @@ sudo /usr/local/apache/bin/apachectl restart
 ---
 
 **維護者**：warden  
-**最後更新**：2026-06-11
-**版本**：2.1
+**最後更新**：2026-06-17
+**版本**：2.2
 
 ### 變更紀錄
 
+- **v2.2 (2026-06-17)**：重新查核 NICS 官網確認 `TWGCB-01-012` 最新仍為 v1.2 (114/6/12)，並補實 v2.1 變更紀錄中尚未實作之檢測項目
+  - `GCB_check.sh`：
+    - `0255` SSH `Protocol` 檢查相容 OpenSSH 7.4+ (未設定視為預設 Protocol 2，符合)
+    - `0235 TMOUT` 與 `0238 umask` 檢查確實擴大涵蓋 `/etc/profile.d/*.sh` 與 `/etc/login.defs`
+    - 新增 `0221` 通行碼 SHA512 雜湊檢查 (login.defs 與 PAM 雙重驗證)
+    - 新增 `0310` even_deny_root 檢查
+    - 新增 `0311` maxsequence 檢查
+    - 新增 `check_cron` 函式：`0189`、`0190/91`、`0192~0201`、`0202/03` cron / at 排程權限
 - **v2.1 (2026-06-11)**：對齊 NICS 發布之 `TWGCB-01-012 v1.2`（中華民國 114 年 6 月 12 日）
   - `GCB_check.sh`：
     - 修正 `TWGCB-01-012-0285~0300` 檔案系統檢查使用實際規則編號（原為 `XXXX` 佔位符）
     - 補齊 `nfs_common (0298)`、`smbfs_common (0300)` 兩項
-    - 修正 `0255` SSH `Protocol` 檢查（OpenSSH 7.4+ 已移除該指令，預設僅支援 Protocol 2）
-    - `0235 TMOUT` 與 `0238 umask` 檢查擴大涵蓋 `/etc/profile.d/*.sh` 與 `/etc/login.defs`
     - 新增 `0033` sudo 套件、`0034` use_pty、`0035` logfile 檢查
-    - 新增 `0221` 通行碼 SHA512 雜湊、`0310` even_deny_root、`0311` maxsequence
-    - 新增 `check_cron` 函式：`0189`、`0190/91`、`0192~0201`、`0202/03` cron / at 權限
 - **v2.0**：新增日誌匯出至 `/var/log/`、檔案數量統計、CLI 統計摘要
 
 如有問題或建議，請透過 GitHub Issues 回報。


### PR DESCRIPTION
## Summary

依照 user 指示查核 https://www.nics.nat.gov.tw/ 後更新 GCB 規則。

**NICS 查核結果**：TWGCB-01-012 (Red Hat Enterprise Linux 9 政府組態基準 - 伺服器) 最新版本仍為 **v1.2 (中華民國 114 年 6 月 12 日)**，未發布更新版本。本專案 `README` v2.1 changelog 雖已宣稱對齊 v1.2，但實際的 `GCB_check.sh` 缺少數項已列出之檢測，本 PR 補實這些項目。

## 變更內容 (`GCB_CHECK/GCB_check.sh`)

- **TWGCB-01-012-0255** SSH `Protocol` 相容 OpenSSH 7.4+：未明確設定時視為預設 `Protocol 2`，符合規範。
- **TWGCB-01-012-0235 / 0238**：`TMOUT` 與 `umask` 檢查擴大涵蓋 `/etc/profile.d/*.sh` 與 `/etc/login.defs` (UMASK 指令)。
- 新增 **TWGCB-01-012-0221**：通行碼雜湊演算法檢查 (`login.defs` 的 `ENCRYPT_METHOD` 與 PAM `system-auth`/`password-auth` 雙重驗證)。
- 新增 **TWGCB-01-012-0310**：`/etc/security/faillock.conf` 的 `even_deny_root` 檢查。
- 新增 **TWGCB-01-012-0311**：`/etc/security/pwquality.conf` 的 `maxsequence` 檢查 (1-3)。
- 新增 `check_cron` 函式，涵蓋：
  - **0189**：crond 服務啟用
  - **0190 / 0191**：`/etc/crontab` 擁有者與權限
  - **0192~0201**：`/etc/cron.{hourly,daily,weekly,monthly,d}` 擁有者與權限
  - **0202**：`/etc/cron.allow` 限制 (移除 `/etc/cron.deny`)
  - **0203**：`/etc/at.allow` 限制 (移除 `/etc/at.deny`)

## Test plan

- [x] `bash -n GCB_CHECK/GCB_check.sh` 通過語法檢查
- [ ] 於 Rocky Linux 9 測試機執行 `sudo ./GCB_CHECK/GCB_check.sh`，確認新增項目 PASS/FAIL 與設定一致
- [ ] 驗證 OpenSSH 7.4+ 預設環境下，0255 顯示為 PASS (不再誤判為 FAIL)
- [ ] 驗證 `/etc/profile.d/gcb-timeout.sh` 內設定 TMOUT 時，0235 可正確抓到值
- [ ] 確認 `check_cron` 函式在已執行 `GCB.sh` 套用設定後的機器上回報 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tXznkVU5u3TmptmMXxVLb

---
_Generated by [Claude Code](https://claude.ai/code/session_017tXznkVU5u3TmptmMXxVLb)_