### PR TITLE
更新 GCB 檢測規則對齊 TWGCB-01-012 v1.2

### DIFF
--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # ==============================================================================
-# Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v3
+# Red Hat Enterprise Linux 9 政府組態基準 (TWGCB-01-012) v1.2 合規性檢測腳本 v4
 #
 # 作者: warden
-# 日期: 2026-06-15
+# 日期: 2026-06-28
 #
 # 功能更新:
 # 1. 新增日誌匯出功能至 /var/log/
@@ -15,6 +15,16 @@
 #    - 新增 sudo 相關檢查 (0033, 0034, 0035)
 #    - 新增 v1.2 新增項目：opasswd 權限 (0303, 0304)、/etc/shells nologin (0305)、
 #      chrony 非 root 執行 (0306)、ptrace 限制模式 (0307)
+# 5. v4 補齊既有 GCB.sh 已套用但檢測未涵蓋之規則：
+#    - 修正 ID 對應：TMOUT 由 0235 修為 0236；umask 由 0238 修為 0239/0240
+#    - 新增 0235 系統帳號 nologin shell、0238 root GID 0 檢查
+#    - 新增 check_cron：0189 crond、0190/91 crontab 權限、0192~0201 cron.* 目錄、
+#      0202/03 cron/at.allow、0204 cron 日誌
+#    - 新增 0221 SHA512 雜湊 (PAM/login.defs)、0309 root umask
+#    - 新增帳戶鎖定相關 0310 even_deny_root/root_unlock_time、0311 maxsequence、
+#      0312 authselect without-nullok
+#    - 修正 0255 SSH Protocol：OpenSSH 7.4+ 已移除指令，未顯式指定 Protocol 1 即 PASS
+#    - 擴大 0236 TMOUT 與 0239/40 umask 檢查至 /etc/profile.d/*.sh 與 /etc/login.defs
 #
 # 來源依據：
 #   國家資通安全研究院 (NICS) TWGCB-01-012 v1.2 (中華民國114年6月12日)
@@ -550,20 +560,167 @@ check_accounts() {
     fi
     print_info "TWGCB-01-012-0224: 提醒：此設定對既有使用者需使用 'chage' 指令個別設定。"
 
-    # TWGCB-01-012-0235: Bash shell 閒置登出時間
-    TMOUT_VAL=$(grep -E '^\s*readonly TMOUT=' /etc/profile /etc/bashrc 2>/dev/null | tail -1 | grep -o '[0-9]*')
-    if [[ "$TMOUT_VAL" -gt 0 && "$TMOUT_VAL" -le 900 ]]; then
-        print_pass "TWGCB-01-012-0235: Bash shell 閒置登出時間為 $TMOUT_VAL 秒，符合 1-900 秒要求。"
+    # TWGCB-01-012-0221: 通行碼雜湊演算法應為 SHA512
+    # 同時檢查 /etc/login.defs 與 PAM 設定檔
+    ENC_METHOD=$(awk '/^\s*ENCRYPT_METHOD/{print $2}' /etc/login.defs 2>/dev/null)
+    PAM_SHA512_OK=1
+    for f in /etc/pam.d/system-auth /etc/pam.d/password-auth; do
+        if [ -f "$f" ] && ! grep -qE '^\s*password\s+\S+\s+pam_unix\.so\b.*\bsha512\b' "$f"; then
+            PAM_SHA512_OK=0
+        fi
+    done
+    if [[ "$ENC_METHOD" == "SHA512" && "$PAM_SHA512_OK" -eq 1 ]]; then
+        print_pass "TWGCB-01-012-0221: 通行碼雜湊演算法 (login.defs + PAM) 已設為 SHA512。"
     else
-        print_fail "TWGCB-01-012-0235: Bash shell 閒置登出時間未設定或不符要求 (目前: $TMOUT_VAL)，應設定在 1-900 秒內。"
+        print_fail "TWGCB-01-012-0221: 通行碼雜湊演算法未完整設為 SHA512 (login.defs: ${ENC_METHOD:-未設定}; PAM 含 sha512: $([[ $PAM_SHA512_OK -eq 1 ]] && echo 是 || echo 否))。"
     fi
 
-    # TWGCB-01-012-0238: 使用者帳號預設 umask
-    UMASK_VAL=$(grep '^\s*umask' /etc/profile /etc/bashrc | tail -n1 | awk '{print $2}')
-    if [[ "$UMASK_VAL" == "027" || "$UMASK_VAL" == "077" ]]; then
-        print_pass "TWGCB-01-012-0238: 使用者預設 umask 為 $UMASK_VAL，符合 027 或更嚴格要求。"
+    # TWGCB-01-012-0310: 帳戶鎖定政策套用至 root (even_deny_root 與 root_unlock_time)
+    EDR=$(grep -hE '^\s*even_deny_root' /etc/security/faillock.conf 2>/dev/null | head -1)
+    RUT=$(grep -hE '^\s*root_unlock_time\s*=' /etc/security/faillock.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$EDR" && -n "$RUT" && "$RUT" -gt 0 ]]; then
+        print_pass "TWGCB-01-012-0310: faillock 已啟用 even_deny_root，root_unlock_time=${RUT}。"
     else
-        print_fail "TWGCB-01-012-0238: 使用者預設 umask 為 $UMASK_VAL，應為 027 或更嚴格。"
+        print_fail "TWGCB-01-012-0310: faillock 未啟用 even_deny_root 或 root_unlock_time 未設定 (root_unlock_time=${RUT:-未設定})。"
+    fi
+
+    # TWGCB-01-012-0311: 通行碼連續字元數量上限 (maxsequence ≤ 3)
+    MAXSEQ=$(grep -E '^\s*maxsequence\s*=' /etc/security/pwquality.conf 2>/dev/null | awk -F= '{print $2}' | xargs)
+    if [[ -n "$MAXSEQ" && "$MAXSEQ" -gt 0 && "$MAXSEQ" -le 3 ]]; then
+        print_pass "TWGCB-01-012-0311: pwquality maxsequence 為 $MAXSEQ，符合 1-3 要求。"
+    else
+        print_fail "TWGCB-01-012-0311: pwquality maxsequence 為 ${MAXSEQ:-未設定}，應設定為 1-3。"
+    fi
+
+    # TWGCB-01-012-0312: authselect 應啟用 without-nullok (禁止空通行碼登入)
+    if command -v authselect >/dev/null 2>&1; then
+        if authselect current 2>/dev/null | grep -q "without-nullok"; then
+            print_pass "TWGCB-01-012-0312: authselect 已啟用 without-nullok。"
+        else
+            # 退而檢查 PAM 設定是否已移除 nullok
+            if ! grep -hE '^\s*(auth|password)\s+\S+\s+pam_unix\.so\b.*\bnullok\b' /etc/pam.d/system-auth /etc/pam.d/password-auth 2>/dev/null | grep -q . ; then
+                print_pass "TWGCB-01-012-0312: PAM 設定中未含 nullok (等效於 without-nullok)。"
+            else
+                print_fail "TWGCB-01-012-0312: authselect 未啟用 without-nullok，且 PAM 仍允許空通行碼。"
+            fi
+        fi
+    else
+        print_skip "TWGCB-01-012-0312: 未安裝 authselect，無法檢查 without-nullok。"
+    fi
+
+    # TWGCB-01-012-0235: 系統帳號 (UID < UID_MIN) 應使用 nologin/false 之 shell
+    UID_MIN=$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs 2>/dev/null)
+    UID_MIN=${UID_MIN:-1000}
+    NOLOGIN_BIN=$(command -v nologin)
+    BAD_SYS_SHELLS=$(awk -F: -v uid_min="$UID_MIN" -v nologin="$NOLOGIN_BIN" '
+        ($1!="root" && $1!="sync" && $1!="shutdown" && $1!="halt" && $3 < uid_min &&
+         $7 != nologin && $7 != "/sbin/nologin" && $7 != "/usr/sbin/nologin" && $7 != "/bin/false") {
+            print $1":"$7
+        }' /etc/passwd)
+    if [ -z "$BAD_SYS_SHELLS" ]; then
+        print_pass "TWGCB-01-012-0235: 所有系統帳號 shell 皆為 nologin/false。"
+    else
+        local details="以下系統帳號 shell 不符要求：\n$BAD_SYS_SHELLS"
+        print_fail "TWGCB-01-012-0235: 部分系統帳號 shell 不為 nologin/false。" "$details"
+    fi
+
+    # TWGCB-01-012-0236: Bash shell 閒置登出時間 (TMOUT)
+    # 涵蓋 /etc/profile、/etc/bashrc 及 /etc/profile.d/*.sh
+    TMOUT_LINE=$(grep -hE '^\s*(readonly\s+)?(export\s+)?TMOUT=' /etc/profile /etc/bashrc /etc/profile.d/*.sh 2>/dev/null | tail -1)
+    TMOUT_VAL=$(echo "$TMOUT_LINE" | grep -oE 'TMOUT=[0-9]+' | head -1 | cut -d= -f2)
+    if [[ -n "$TMOUT_VAL" && "$TMOUT_VAL" -gt 0 && "$TMOUT_VAL" -le 900 ]]; then
+        print_pass "TWGCB-01-012-0236: Bash shell 閒置登出時間為 $TMOUT_VAL 秒，符合 1-900 秒要求。"
+    else
+        print_fail "TWGCB-01-012-0236: Bash shell 閒置登出時間未設定或不符要求 (目前: ${TMOUT_VAL:-未設定})，應設定在 1-900 秒內。"
+    fi
+
+    # TWGCB-01-012-0238: root 帳號所屬群組應為 GID 0
+    ROOT_GID=$(awk -F: '$1=="root"{print $4}' /etc/passwd)
+    if [[ "$ROOT_GID" == "0" ]]; then
+        print_pass "TWGCB-01-012-0238: root 帳號之主要群組 GID 為 0。"
+    else
+        print_fail "TWGCB-01-012-0238: root 帳號之主要群組 GID 為 $ROOT_GID，應為 0。"
+    fi
+
+    # TWGCB-01-012-0239/0240: 使用者帳號預設 umask
+    # 涵蓋 /etc/profile、/etc/bashrc、/etc/profile.d/*.sh 與 /etc/login.defs (UMASK)
+    UMASK_VAL=$(grep -hE '^\s*umask\s+' /etc/profile /etc/bashrc /etc/profile.d/*.sh 2>/dev/null | tail -n1 | awk '{print $2}')
+    UMASK_LOGIN_DEFS=$(awk '/^\s*UMASK/{print $2}' /etc/login.defs 2>/dev/null)
+    umask_ok() { [[ "$1" == "027" || "$1" == "077" ]]; }
+    if umask_ok "$UMASK_VAL" && umask_ok "$UMASK_LOGIN_DEFS"; then
+        print_pass "TWGCB-01-012-0239/40: shell umask=$UMASK_VAL, /etc/login.defs UMASK=$UMASK_LOGIN_DEFS，皆為 027 或更嚴格。"
+    else
+        print_fail "TWGCB-01-012-0239/40: shell umask=${UMASK_VAL:-未設定}, /etc/login.defs UMASK=${UMASK_LOGIN_DEFS:-未設定}，皆應為 027 或更嚴格。"
+    fi
+
+    # TWGCB-01-012-0309: root 帳號預設 umask (/root/.bashrc 與 /root/.bash_profile)
+    ROOT_UMASK_BASHRC=$(grep -hE '^\s*umask\s+' /root/.bashrc 2>/dev/null | tail -n1 | awk '{print $2}')
+    ROOT_UMASK_PROFILE=$(grep -hE '^\s*umask\s+' /root/.bash_profile 2>/dev/null | tail -n1 | awk '{print $2}')
+    if umask_ok "$ROOT_UMASK_BASHRC" && umask_ok "$ROOT_UMASK_PROFILE"; then
+        print_pass "TWGCB-01-012-0309: root 之 .bashrc/.bash_profile umask 為 027 或更嚴格。"
+    else
+        print_fail "TWGCB-01-012-0309: root 之 umask 未正確設定 (.bashrc=${ROOT_UMASK_BASHRC:-未設定}, .bash_profile=${ROOT_UMASK_PROFILE:-未設定})。"
+    fi
+}
+
+# cron 與 at
+check_cron() {
+    print_header "cron 與 at"
+
+    # TWGCB-01-012-0189: 啟用 crond 服務
+    if systemctl is-enabled crond &>/dev/null && systemctl is-active crond &>/dev/null; then
+        print_pass "TWGCB-01-012-0189: crond 服務已啟用且運行中。"
+    else
+        print_fail "TWGCB-01-012-0189: crond 服務未啟用或未運行 (enabled=$(systemctl is-enabled crond 2>/dev/null), active=$(systemctl is-active crond 2>/dev/null))。"
+    fi
+
+    # TWGCB-01-012-0190/0191: /etc/crontab 權限與擁有者
+    if [ -f /etc/crontab ]; then
+        check_file_perms_owner "TWGCB-01-012-0190/91" "/etc/crontab" "600" "root:root"
+    else
+        print_info "TWGCB-01-012-0190/91: /etc/crontab 不存在。"
+    fi
+
+    # TWGCB-01-012-0192~0201: /etc/cron.{hourly,daily,weekly,monthly,d} 權限與擁有者
+    declare -A CRON_DIR_IDS=(
+        ["/etc/cron.hourly"]="0192/93"
+        ["/etc/cron.daily"]="0194/95"
+        ["/etc/cron.weekly"]="0196/97"
+        ["/etc/cron.monthly"]="0198/99"
+        ["/etc/cron.d"]="0200/01"
+    )
+    for dir in "${!CRON_DIR_IDS[@]}"; do
+        id="${CRON_DIR_IDS[$dir]}"
+        if [ -d "$dir" ]; then
+            check_file_perms_owner "TWGCB-01-012-${id}" "$dir" "700" "root:root"
+        else
+            print_info "TWGCB-01-012-${id}: ${dir} 不存在。"
+        fi
+    done
+
+    # TWGCB-01-012-0202: 限制 cron 使用者 (應使用 cron.allow 而非 cron.deny)
+    if [ -e /etc/cron.deny ]; then
+        print_fail "TWGCB-01-012-0202: /etc/cron.deny 存在，應改用 /etc/cron.allow 並移除 cron.deny。"
+    elif [ -f /etc/cron.allow ]; then
+        check_file_perms_owner "TWGCB-01-012-0202" "/etc/cron.allow" "600" "root:root"
+    else
+        print_fail "TWGCB-01-012-0202: /etc/cron.allow 不存在，應建立以限制 cron 使用者。"
+    fi
+
+    # TWGCB-01-012-0203: 限制 at 使用者
+    if [ -e /etc/at.deny ]; then
+        print_fail "TWGCB-01-012-0203: /etc/at.deny 存在，應改用 /etc/at.allow 並移除 at.deny。"
+    elif [ -f /etc/at.allow ]; then
+        check_file_perms_owner "TWGCB-01-012-0203" "/etc/at.allow" "600" "root:root"
+    else
+        print_fail "TWGCB-01-012-0203: /etc/at.allow 不存在，應建立以限制 at 使用者。"
+    fi
+
+    # TWGCB-01-012-0204: 啟用 cron 日誌記錄
+    if grep -rhqE '^\s*cron\.\*\s+/var/log/cron' /etc/rsyslog.conf /etc/rsyslog.d/ 2>/dev/null; then
+        print_pass "TWGCB-01-012-0204: rsyslog 已啟用 cron 日誌記錄。"
+    else
+        print_fail "TWGCB-01-012-0204: rsyslog 未啟用 cron 日誌記錄 (應在 /etc/rsyslog.d/ 中加入 cron.* /var/log/cron)。"
     fi
 }
 
@@ -578,7 +735,15 @@ check_ssh() {
     fi
     
     # TWGCB-01-012-0255: SSH 協定版本
-    grep -qE "^\s*Protocol\s+2" "$SSHD_CONFIG" && print_pass "TWGCB-01-012-0255: SSH 協定版本已設為 2。" || print_fail "TWGCB-01-012-0255: SSH 協定版本未設為 2。"
+    # OpenSSH 7.4+ 已移除 Protocol 指令並預設僅支援 Protocol 2，
+    # 因此「未明示」即視為合規；僅當顯式設定 Protocol 1 時才判定不合規。
+    if grep -qE "^\s*Protocol\s+1\b" "$SSHD_CONFIG"; then
+        print_fail "TWGCB-01-012-0255: SSH 已顯式設定 Protocol 1，應改為 2 或移除該指令。"
+    elif grep -qE "^\s*Protocol\s+2\b" "$SSHD_CONFIG"; then
+        print_pass "TWGCB-01-012-0255: SSH 協定版本已設為 2。"
+    else
+        print_pass "TWGCB-01-012-0255: 未顯式設定 Protocol (OpenSSH 7.4+ 預設僅支援 Protocol 2)。"
+    fi
 
     # TWGCB-01-012-0256 & 0257: sshd_config 檔案權限
     check_file_perms_owner "TWGCB-01-012-0256/57" "$SSHD_CONFIG" "600" "root:root"
@@ -653,6 +818,7 @@ main() {
     check_network
     check_selinux
     check_accounts
+    check_cron
     check_ssh
 
     print_summary

--- a/GCB_CHECK/GCB_check.sh
+++ b/GCB_CHECK/GCB_check.sh
@@ -23,6 +23,7 @@
 #    - 新增 0221 SHA512 雜湊 (PAM/login.defs)、0309 root umask
 #    - 新增帳戶鎖定相關 0310 even_deny_root/root_unlock_time、0311 maxsequence、
 #      0312 authselect without-nullok
+#    - 新增 0308 rsyslog logrotate、0315 SSH GSSAPIAuthentication 檢查
 #    - 修正 0255 SSH Protocol：OpenSSH 7.4+ 已移除指令，未顯式指定 Protocol 1 即 PASS
 #    - 擴大 0236 TMOUT 與 0239/40 umask 檢查至 /etc/profile.d/*.sh 與 /etc/login.defs
 #
@@ -661,6 +662,15 @@ check_accounts() {
     else
         print_fail "TWGCB-01-012-0309: root 之 umask 未正確設定 (.bashrc=${ROOT_UMASK_BASHRC:-未設定}, .bash_profile=${ROOT_UMASK_PROFILE:-未設定})。"
     fi
+
+    # TWGCB-01-012-0308: rsyslog logrotate 設定
+    if [ -f /etc/logrotate.d/rsyslog ] && \
+       grep -qE '^\s*(weekly|daily|monthly)' /etc/logrotate.d/rsyslog && \
+       grep -qE '^\s*rotate\s+[0-9]+' /etc/logrotate.d/rsyslog; then
+        print_pass "TWGCB-01-012-0308: /etc/logrotate.d/rsyslog 已設定 logrotate 規則。"
+    else
+        print_fail "TWGCB-01-012-0308: /etc/logrotate.d/rsyslog 缺少必要之 logrotate 設定。"
+    fi
 }
 
 # cron 與 at
@@ -773,6 +783,13 @@ check_ssh() {
 
     # TWGCB-01-012-0274: SSH UsePAM
     grep -qE "^\s*UsePAM\s+yes" "$SSHD_CONFIG" && print_pass "TWGCB-01-012-0274: SSH UsePAM 已設為 yes。" || print_fail "TWGCB-01-012-0274: SSH UsePAM 未設為 yes。"
+
+    # TWGCB-01-012-0315: 停用 GSSAPI 驗證
+    if grep -qE "^\s*GSSAPIAuthentication\s+no" "$SSHD_CONFIG"; then
+        print_pass "TWGCB-01-012-0315: SSH GSSAPIAuthentication 已設為 no。"
+    else
+        print_fail "TWGCB-01-012-0315: SSH GSSAPIAuthentication 未設為 no。"
+    fi
 
 }
 

--- a/GCB_SET/GCB.sh
+++ b/GCB_SET/GCB.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # ==============================================================================
-# Red Hat Enterprise Linux 9 GCB 組態基準套用腳本 (v1.2)
+# Red Hat Enterprise Linux 9 GCB 組態基準套用腳本 (v1.2, 1140612)
 # ------------------------------------------------------------------------------
 # 來源文件: TWGCB-01-012_Red Hat Enterprise Linux 9政府組態基準說明文件(伺服器)v1.2
+# 發行日期: 中華民國114年6月12日 (2025-06-12) by NICS
 # 產生日期: 2025-06-17
 # 作者:warden
 #
@@ -374,12 +375,16 @@ apply_system_settings() {
     fi
     
     echo "[*] TWGCB-01-012-0306: 禁止 chrony 以 root 權限執行..."
-    if grep -q "OPTIONS=" /etc/sysconfig/chronyd; then
-        sed -i 's/OPTIONS=".*"/OPTIONS="-F 2"/' /etc/sysconfig/chronyd
+    if [ -f /etc/sysconfig/chronyd ]; then
+        if grep -qE '^\s*OPTIONS=' /etc/sysconfig/chronyd; then
+            sed -i -E 's/^\s*OPTIONS=.*/OPTIONS="-F 2"/' /etc/sysconfig/chronyd
+        else
+            echo 'OPTIONS="-F 2"' >> /etc/sysconfig/chronyd
+        fi
     else
-        echo 'OPTIONS="-F 2"' >> /etc/sysconfig/chronyd
+        echo 'OPTIONS="-F 2"' > /etc/sysconfig/chronyd
     fi
-    systemctl restart chronyd.service
+    systemctl restart chronyd.service 2>/dev/null || true
 
     echo "[*] TWGCB-01-012-0307: 啟用 ptrace 限制模式..."
     echo "kernel.yama.ptrace_scope = 1" >> /etc/sysctl.d/60-gcb.conf

--- a/README.md
+++ b/README.md
@@ -337,20 +337,38 @@ sudo /usr/local/apache/bin/apachectl restart
 ---
 
 **維護者**：warden  
-**最後更新**：2026-06-11
-**版本**：2.1
+**最後更新**：2026-06-28
+**版本**：2.2
 
 ### 變更紀錄
 
+- **v2.2 (2026-06-28)**：補齊 `GCB_check.sh` 與 `GCB.sh` 之間的規則差異，並修正錯誤的 TWGCB ID 對應
+  - 來源依據：NICS `TWGCB-01-012 v1.2`（中華民國 114 年 6 月 12 日，當前最新版本）
+  - `GCB_check.sh`：
+    - 修正 ID 對應錯誤：原 `0235`（TMOUT）→ `0236`；原 `0238`（umask）→ `0239/0240`
+    - 新增 `0235` 系統帳號 shell 為 `nologin/false` 檢查
+    - 新增 `0238` root 帳號主要群組 GID = 0 檢查
+    - 新增 `0309` root 帳號 `.bashrc`/`.bash_profile` 之 umask 檢查
+    - 擴大 `0236 TMOUT` 與 `0239/40 umask` 檢查至 `/etc/profile.d/*.sh` 與 `/etc/login.defs (UMASK)`
+    - 修正 `0255` SSH `Protocol` 檢查：未顯式設定即視為合規（OpenSSH 7.4+ 已移除該指令）；
+      僅當顯式設定 `Protocol 1` 時判定為不合規
+    - 新增 `0221` 通行碼 SHA512 雜湊（同時檢查 `/etc/login.defs` 與 PAM）
+    - 新增 `0310` faillock `even_deny_root` 與 `root_unlock_time` 檢查
+    - 新增 `0311` pwquality `maxsequence` (≤3) 檢查
+    - 新增 `0312` authselect `without-nullok`（或 PAM 不含 `nullok`）檢查
+    - 新增 `check_cron` 函式：
+      - `0189` crond 服務、`0190/91` `/etc/crontab` 權限與擁有者
+      - `0192/93`~`0200/01` `/etc/cron.{hourly,daily,weekly,monthly,d}` 目錄權限
+      - `0202` cron 使用者限制（`cron.allow` 並移除 `cron.deny`）
+      - `0203` at 使用者限制（`at.allow` 並移除 `at.deny`）
+      - `0204` rsyslog 啟用 cron 日誌記錄
 - **v2.1 (2026-06-11)**：對齊 NICS 發布之 `TWGCB-01-012 v1.2`（中華民國 114 年 6 月 12 日）
   - `GCB_check.sh`：
     - 修正 `TWGCB-01-012-0285~0300` 檔案系統檢查使用實際規則編號（原為 `XXXX` 佔位符）
     - 補齊 `nfs_common (0298)`、`smbfs_common (0300)` 兩項
-    - 修正 `0255` SSH `Protocol` 檢查（OpenSSH 7.4+ 已移除該指令，預設僅支援 Protocol 2）
-    - `0235 TMOUT` 與 `0238 umask` 檢查擴大涵蓋 `/etc/profile.d/*.sh` 與 `/etc/login.defs`
     - 新增 `0033` sudo 套件、`0034` use_pty、`0035` logfile 檢查
-    - 新增 `0221` 通行碼 SHA512 雜湊、`0310` even_deny_root、`0311` maxsequence
-    - 新增 `check_cron` 函式：`0189`、`0190/91`、`0192~0201`、`0202/03` cron / at 權限
+    - 新增 v1.2 新增項目：opasswd 權限 (`0303`, `0304`)、`/etc/shells nologin` (`0305`)、
+      chrony 非 root 執行 (`0306`)、ptrace 限制模式 (`0307`)
 - **v2.0**：新增日誌匯出至 `/var/log/`、檔案數量統計、CLI 統計摘要
 
 如有問題或建議，請透過 GitHub Issues 回報。

--- a/README.md
+++ b/README.md
@@ -356,12 +356,16 @@ sudo /usr/local/apache/bin/apachectl restart
     - 新增 `0310` faillock `even_deny_root` 與 `root_unlock_time` 檢查
     - 新增 `0311` pwquality `maxsequence` (≤3) 檢查
     - 新增 `0312` authselect `without-nullok`（或 PAM 不含 `nullok`）檢查
+    - 新增 `0308` rsyslog logrotate 與 `0315` SSH `GSSAPIAuthentication=no` 檢查
     - 新增 `check_cron` 函式：
       - `0189` crond 服務、`0190/91` `/etc/crontab` 權限與擁有者
       - `0192/93`~`0200/01` `/etc/cron.{hourly,daily,weekly,monthly,d}` 目錄權限
       - `0202` cron 使用者限制（`cron.allow` 並移除 `cron.deny`）
       - `0203` at 使用者限制（`at.allow` 並移除 `at.deny`）
       - `0204` rsyslog 啟用 cron 日誌記錄
+  - `GCB.sh`：
+    - Header 補上 `(1140612)` 版本標記與 NICS 發行日期
+    - 修正 `0306` chronyd `OPTIONS` 設定，正確移除既有 `-u root` 參數
 - **v2.1 (2026-06-11)**：對齊 NICS 發布之 `TWGCB-01-012 v1.2`（中華民國 114 年 6 月 12 日）
   - `GCB_check.sh`：
     - 修正 `TWGCB-01-012-0285~0300` 檔案系統檢查使用實際規則編號（原為 `XXXX` 佔位符）


### PR DESCRIPTION
## 摘要

依據 NICS 公告之 **TWGCB-01-012 Red Hat Enterprise Linux 9 政府組態基準說明文件(伺服器) v1.2**（中華民國 114 年 6 月 12 日）核對檢測腳本與設定腳本，補齊 `GCB_check.sh` 與 `GCB.sh` 之間的規則差異，並修正錯誤的 TWGCB ID 對應。

> 註：嘗試直接連線 https://www.nics.nat.gov.tw/ 取得最新文件時持續回應 HTTP 403，改以 web search 確認最新版本仍為 v1.2 (1140612)。本次以 `GCB.sh` 已套用之 v1.2 規則為基準補齊檢測項目。

## 主要變更

### 修正 ID 對應錯誤
原 `GCB_check.sh` 中 TMOUT / umask 之 ID 與 `GCB.sh` (v1.2) 不一致：

| 項目 | 修正前 | 修正後 |
| --- | --- | --- |
| Bash TMOUT | `0235` | `0236` |
| 使用者 umask | `0238` | `0239/0240` |

`0235`、`0238` 為其他規則，原本完全未檢測，本次補齊：

- `0235` 系統帳號 shell 為 `nologin`/`false`
- `0238` root 帳號主要群組 GID = 0
- `0309` root 帳號 `.bashrc`/`.bash_profile` 之 umask

### 新增 `check_cron` 函式
- `0189` `crond` 服務啟用且運行中
- `0190/91` `/etc/crontab` 權限與擁有者
- `0192/93` ~ `0200/01` `/etc/cron.{hourly,daily,weekly,monthly,d}` 目錄權限
- `0202` cron 使用者限制（`cron.allow` 並移除 `cron.deny`）
- `0203` at 使用者限制（`at.allow` 並移除 `at.deny`）
- `0204` rsyslog 啟用 cron 日誌記錄

### 新增 PAM / 通行碼政策檢查
- `0221` 通行碼 SHA512 雜湊（同時檢查 `/etc/login.defs` 與 PAM）
- `0310` faillock `even_deny_root` 與 `root_unlock_time`
- `0311` pwquality `maxsequence` (1-3)
- `0312` authselect `without-nullok`（或 PAM 不含 `nullok`）

### 修正既有檢查
- `0255` SSH `Protocol`：未顯式設定即視為合規（OpenSSH 7.4+ 已移除該指令並預設僅支援 Protocol 2）；僅當顯式設定 `Protocol 1` 時才判定不合規
- `0236` TMOUT 與 `0239/40` umask 之檢查路徑擴大涵蓋 `/etc/profile.d/*.sh` 與 `/etc/login.defs (UMASK)`

### 文件
- `README.md` 維護者版本提升至 **v2.2 (2026-06-28)** 並新增 v2.2 變更紀錄

## 測試計畫

- [x] `bash -n GCB_CHECK/GCB_check.sh` 語法檢查通過
- [ ] 在 Rocky Linux 9 測試機上以 root 執行 `GCB_check.sh`，驗證新增之 cron / PAM 檢查在套用 `GCB.sh` 前後分別呈現 FAIL → PASS
- [ ] 驗證 `0255` 在三種狀態下行為正確：未設定 / `Protocol 2` / `Protocol 1`
- [ ] 驗證 TMOUT、umask 在 `/etc/profile.d/gcb-timeout.sh` 與 `/etc/login.defs` 設定後可正確判定 PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xqQF47ztTqBkgDfvVqUVt)_